### PR TITLE
Logger refactor: Pull AWS region from correct fargate endpoint

### DIFF
--- a/src/i_dot_ai_utilities/logging/__tests__/test_enricher_fargate.py
+++ b/src/i_dot_ai_utilities/logging/__tests__/test_enricher_fargate.py
@@ -1,6 +1,7 @@
 # mypy: disable-error-code="no-untyped-def"
 
 import json
+import os
 from unittest.mock import patch
 
 import pytest
@@ -9,26 +10,38 @@ import i_dot_ai_utilities
 from i_dot_ai_utilities.logging.structured_logger import StructuredLogger
 from i_dot_ai_utilities.logging.types.enrichment_types import ExecutionEnvironmentType
 
+base_metadata_url = "https://test-base-container-url"
+os.environ["ECS_CONTAINER_METADATA_URI_V4"] = base_metadata_url
 
-@pytest.fixture
-def load_test_metadata_object():
+def load_test_container_metadata_object():
     test_arn = "arn:aws:ecs:us-east-1:123456789012:task/testcluster/testarn"  # aws-ignore
     return {
         "ImageID": "image12345",
         "StartedAt": "2023-07-21T15:45:44.954460255Z",
         "Labels": {
             "com.amazonaws.ecs.task-arn": test_arn,
-        },
+        }
+    }
+
+def load_test_task_metadata_object():
+    return {
         "AvailabilityZone": "eu-test-1a",
     }
 
+def load_mock_metadata_response(arg):
+    if arg == base_metadata_url:
+        return load_test_container_metadata_object()
+    elif arg == f"{base_metadata_url}/task":
+        return load_test_task_metadata_object()
+    else:
+        raise Exception("Incorrect arg")
 
 @patch.object(
     i_dot_ai_utilities.logging.enrichers.fargate_enricher.FargateEnvironmentEnricher,
     "_get_metadata_response",
 )
-def test_fargate_enriched_logger_contains_expected_fields(mocked_metadata_response, load_test_metadata_object, capsys):
-    mocked_metadata_response.return_value = load_test_metadata_object
+def test_fargate_enriched_logger_contains_expected_fields(mocked_metadata_response, capsys):
+    mocked_metadata_response.side_effect = load_mock_metadata_response
 
     logger = StructuredLogger(
         level="info",
@@ -45,11 +58,11 @@ def test_fargate_enriched_logger_contains_expected_fields(mocked_metadata_respon
         parsed.append(json.loads(line))
 
     fargate = parsed[0].get("fargate")
-
-    assert fargate.get("image_id") == load_test_metadata_object["ImageID"]
-    assert fargate.get("task_arn") == load_test_metadata_object["Labels"]["com.amazonaws.ecs.task-arn"]
-    assert fargate.get("container_started_at") == load_test_metadata_object["StartedAt"]
-    assert fargate.get("aws_region") == load_test_metadata_object["AvailabilityZone"][:-1]
+    print(fargate)
+    assert fargate.get("image_id") == load_test_container_metadata_object()["ImageID"]
+    assert fargate.get("task_arn") == load_test_container_metadata_object()["Labels"]["com.amazonaws.ecs.task-arn"]
+    assert fargate.get("container_started_at") == load_test_container_metadata_object()["StartedAt"]
+    assert fargate.get("aws_region") == load_test_task_metadata_object()["AvailabilityZone"][:-1]
 
 
 @pytest.mark.parametrize(
@@ -87,6 +100,8 @@ def test_fargate_enrichment_handles_malformed_response_object(
 
 
 def test_logger_handles_exception_if_outside_of_fargate_environment(capsys):
+    del os.environ["ECS_CONTAINER_METADATA_URI_V4"]
+    
     logger = StructuredLogger(
         level="info",
         options={"execution_environment": ExecutionEnvironmentType.FARGATE},

--- a/src/i_dot_ai_utilities/logging/enrichers/fargate_enricher.py
+++ b/src/i_dot_ai_utilities/logging/enrichers/fargate_enricher.py
@@ -19,15 +19,24 @@ class FargateEnvironmentEnricher(BaseEnvironmentEnricher):
     def extract_context(self, self_logger: Any) -> ExtractedFargateContext | None:
         response: ExtractedFargateContext | None = None
         try:
-            metadata_response = self._get_metadata_response()
-            loaded_metadata = FargateContainerMetadataResponse(metadata_response)
+            base_url = os.environ.get(self._container_metadata_url_parameter_name, None)
 
+            if base_url is None:
+                msg = "Failed to find metadata URL on environment"
+                raise ValueError(msg)
+
+            container_metadata_response = self._get_metadata_response(base_url)
+            container_loaded_metadata = FargateContainerMetadataResponse(container_metadata_response)
+
+            task_metadata_response = self._get_metadata_response(f"{base_url}/task")
+            task_loaded_metadata = FargateTaskMetadataResponse(task_metadata_response)
+            
             response = {
                 "fargate": {
-                    "image_id": loaded_metadata.image_id,
-                    "task_arn": loaded_metadata.labels.task_arn,
-                    "container_started_at": loaded_metadata.started_at,
-                    "aws_region": loaded_metadata.aws_region,
+                    "image_id": container_loaded_metadata.image_id,
+                    "task_arn": container_loaded_metadata.labels.task_arn,
+                    "container_started_at": container_loaded_metadata.started_at,
+                    "aws_region": task_loaded_metadata.aws_region,
                 }
             }
         except Exception:
@@ -36,12 +45,7 @@ class FargateEnvironmentEnricher(BaseEnvironmentEnricher):
         else:
             return response
 
-    def _get_metadata_response(self) -> Any:
-        url = os.environ.get(self._container_metadata_url_parameter_name, None)
-
-        if url is None:
-            msg = "Failed to find metadata URL on environment"
-            raise ValueError(msg)
+    def _get_metadata_response(self, url: str) -> Any:
 
         parsed_url = urlparse(url)
         if parsed_url.scheme not in ("http", "https"):
@@ -58,8 +62,16 @@ class FargateContainerMetadataResponse:
             self.image_id: str = raw_response["ImageID"]
             self.started_at: str = raw_response["StartedAt"]
             self.labels: FargateContainerLabelsLike = FargateContainerLabelsLike(raw_response["Labels"])
-            self.aws_region: str = raw_response["AvailabilityZone"][:-1]
 
         except Exception as e:
             msg = "Exception(Logger): Response doesn't conform to FargateContainerMetadataResponse. Context not set."
+            raise TypeError(msg) from e
+
+class FargateTaskMetadataResponse:
+    def __init__(self, raw_response: dict[str, Any]):
+        try:
+            self.aws_region: str = raw_response["AvailabilityZone"][:-1]
+
+        except Exception as e:
+            msg = "Exception(Logger): Response doesn't conform to FargateTaskMetadataResponse. Context not set."
             raise TypeError(msg) from e

--- a/src/i_dot_ai_utilities/logging/types/context_enrichment_options.py
+++ b/src/i_dot_ai_utilities/logging/types/context_enrichment_options.py
@@ -4,8 +4,9 @@ from i_dot_ai_utilities.logging.enrichers.enrichment_provider import (
     ContextEnrichmentType,
 )
 from i_dot_ai_utilities.logging.enrichers.fastapi_enricher import RequestLike
+from i_dot_ai_utilities.logging.types.lambda_enrichment_schema import LambdaContextLike
 
 
 class ContextEnrichmentOptions(TypedDict):
     type: ContextEnrichmentType
-    object: RequestLike
+    object: RequestLike | LambdaContextLike


### PR DESCRIPTION
Refactor to call out to the `/task` endpoint for the aws_region instead of the base metadata url.

Also adds a missing type for the lambda context injection
