### PR TITLE
Fix Python 3.10 compatibility issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "minio>=7.2.15",
     "requests>=2.32.3",
     "structlog>=25.4.0",
+    "typing_extensions>=4.0.0",
 ]
 
 [project.urls]

--- a/src/i_dot_ai_utilities/logging/types/logger_config_options.py
+++ b/src/i_dot_ai_utilities/logging/types/logger_config_options.py
@@ -1,4 +1,10 @@
-from typing import NotRequired, TypedDict
+# In logger_config_options.py
+from typing import TypedDict
+try:
+    from typing import NotRequired
+except ImportError:
+    from typing_extensions import NotRequired
+
 
 from i_dot_ai_utilities.logging.enrichers.enrichment_provider import (
     ExecutionEnvironmentType,

--- a/src/i_dot_ai_utilities/logging/types/logger_config_options.py
+++ b/src/i_dot_ai_utilities/logging/types/logger_config_options.py
@@ -1,4 +1,5 @@
 from typing import TypedDict
+
 try:
     from typing import NotRequired
 except ImportError:

--- a/src/i_dot_ai_utilities/logging/types/logger_config_options.py
+++ b/src/i_dot_ai_utilities/logging/types/logger_config_options.py
@@ -1,4 +1,3 @@
-# In logger_config_options.py
 from typing import TypedDict
 try:
     from typing import NotRequired

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10, <4.0"
 
 [[package]]
@@ -350,6 +350,7 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "requests" },
     { name = "structlog" },
+    { name = "typing-extensions" },
 ]
 
 [package.optional-dependencies]
@@ -373,7 +374,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "boto3", specifier = ">=1.38.35" },
+    { name = "boto3", specifier = ">=1.38.23,<2.0.0" },
     { name = "minio", specifier = ">=7.2.15" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.15.0" },
     { name = "pydantic", specifier = ">=2.11.7" },
@@ -383,6 +384,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.32.3" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.2" },
     { name = "structlog", specifier = ">=25.4.0" },
+    { name = "typing-extensions", specifier = ">=4.0.0" },
 ]
 provides-extras = ["dev"]
 


### PR DESCRIPTION
### Problem
The centralised logger fails to import in Python 3.10 environments with the following error:

```
File "/usr/local/lib/python3.10/site-packages/i_dot_ai_utilities/logging/types/logger_config_options.py", line 1, in <module>
 from typing import NotRequired, TypedDict
ImportError: cannot import name 'NotRequired' from 'typing' (/usr/local/lib/python3.10/typing.py)
```

### Root Cause
`NotRequired` was introduced in `Python 3.11`, but our package supports `Python 3.10+` as specified in `pyproject.toml`. This creates a compatibility gap for `Python 3.10` usage.

https://typing-extensions.readthedocs.io/en/latest/#typing_extensions.NotRequired
