### PR TITLE
feat(logging): add OpenTelemetry logging util and middleware

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -5,6 +5,19 @@ on:
     types:
       - released
       - prereleased
+  workflow_dispatch:
+    inputs:
+      pypi:
+        description: "Target index. Manual runs are pre-release only."
+        type: choice
+        options:
+          - production
+          - test
+        default: test
+      version:
+        description: "Existing tag to publish (must already exist, e.g. 0.6.0rc1)."
+        type: string
+        required: true
 
 jobs:
   deploy:
@@ -13,29 +26,98 @@ jobs:
     permissions:
         id-token: write
         contents: read
+    outputs:
+      target: ${{ steps.resolve.outputs.target }}
+      tag: ${{ steps.resolve.outputs.tag }}
+      version: ${{ steps.resolve.outputs.version }}
+      maturity: ${{ steps.resolve.outputs.maturity }}
     steps:
+    - name: Resolve release target
+      id: resolve
+      env:
+        EVENT_NAME: ${{ github.event_name }}
+        INPUT_PYPI: ${{ inputs.pypi }}
+        INPUT_VERSION: ${{ inputs.version }}
+        RELEASE_TAG: ${{ github.event.release.tag_name }}
+        RELEASE_PRERELEASE: ${{ github.event.release.prerelease }}
+      run: |
+        set -euo pipefail
+
+        # A PEP 440 pre-release carries an a/b/rc/.dev suffix on the base
+        # X.Y.Z version (case-insensitive). Stable versions do not.
+        is_prerelease() {
+          printf '%s' "$1" | grep -Eiq '^[0-9]+\.[0-9]+\.[0-9]+(rc|a|b|\.dev)'
+        }
+
+        if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+          target="$INPUT_PYPI"
+          tag="$INPUT_VERSION"
+
+          if is_prerelease "$tag"; then
+            maturity="prerelease"
+          else
+            maturity="stable"
+          fi
+
+          # Guardrail: manual dispatch is pre-release only. A stable version
+          # must go through the normal GitHub Release flow, never a manual
+          # publish, to avoid two divergent routes to a production stable
+          # release.
+          if [ "$target" = "production" ] && [ "$maturity" != "prerelease" ]; then
+            echo "::error::Manual dispatch to production is pre-release only. '$tag' is not a PEP 440 pre-release (expected an rc/a/b/.dev suffix). Cut a stable release via the GitHub Release flow instead."
+            exit 1
+          fi
+        else
+          # GitHub Release event: keep today's routing. A GitHub pre-release
+          # goes to Test PyPI; a full release goes to production PyPI.
+          tag="$RELEASE_TAG"
+          if [ "$RELEASE_PRERELEASE" = "true" ]; then
+            target="test"
+            maturity="prerelease"
+          else
+            target="production"
+            maturity="stable"
+          fi
+        fi
+
+        # Version-string stamping (see README CI/CD & Releases):
+        # - test:                  <tag>.<timestamp>  (avoids Test PyPI
+        #                          filename-reuse rejections on re-upload)
+        # - production pre-release: <tag> verbatim     (clean PEP 440 rc so
+        #                          pip ignores it without --pre)
+        # - production stable:      <tag> verbatim
+        if [ "$target" = "test" ]; then
+          timestamp="$(date +"%Y%m%d%H%M")"
+          version="${tag}.${timestamp}"
+        else
+          version="$tag"
+        fi
+
+        {
+          echo "target=$target"
+          echo "tag=$tag"
+          echo "version=$version"
+          echo "maturity=$maturity"
+        } >> "$GITHUB_OUTPUT"
+
+        echo "Resolved: event=$EVENT_NAME target=$target maturity=$maturity tag=$tag version=$version"
+
     - name: Validate semantic version
       uses: matt-usurp/validate-semver@7bbc9584679de1aeef57aa531504ab00438481ab
       with:
-        version: ${{ github.event.release.tag_name }}
+        version: ${{ steps.resolve.outputs.tag }}
 
     - name: Checkout repository
       uses: actions/checkout@v4
       with:
           fetch-depth: 0
+          ref: ${{ steps.resolve.outputs.tag }}
 
     - name: Install uv
       uses: astral-sh/setup-uv@v4
 
-    - name: Set test release version
-      if: github.event.release.prerelease == true
-      run: |
-        timestamp=$(date +"%Y%m%d%H%M")
-        uv version ${{ github.event.release.tag_name }}.$timestamp
-
-    - name: Set prod release version
-      if: github.event.release.prerelease == false
-      run: uv version ${{ github.event.release.tag_name }}
+    - name: Set package version
+      run: uv version ${{ steps.resolve.outputs.version }}
 
     - name: Install dependencies
       run: uv sync
@@ -43,16 +125,16 @@ jobs:
     - name: Build
       run: uv build
 
-    - name: Publish to test pypi
+    - name: Publish to test PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
-      if: github.event.release.prerelease == true
+      if: steps.resolve.outputs.target == 'test'
       with:
         repository-url: 'https://test.pypi.org/legacy/'
         verbose: true
 
-    - name: Publish to prod pypi
+    - name: Publish to production PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
-      if: github.event.release.prerelease == false
+      if: steps.resolve.outputs.target == 'production'
 
   determine-success:
     if: always()
@@ -78,7 +160,7 @@ jobs:
       - determine-success
     with:
       WORKFLOW_PASSED: ${{ needs.determine-success.outputs.success == 'true' }}
-      SUCCESS_PAYLOAD: "{\"blocks\":[{\"type\":\"header\",\"text\":{\"type\":\"plain_text\",\"text\":\":airplane: ${{ github.repository }} - Successfully deployed ${{ github.event.release.tag_name }}${{ github.event.release.prerelease && ' (Pre-Release)' || '' }} :large_green_circle:\"}},{\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\"Package published to${{ github.event.release.prerelease && ' test' || '' }} PyPI successfully\"}}]}"
-      FAILURE_PAYLOAD: "{\"blocks\":[{\"type\":\"header\",\"text\":{\"type\":\"plain_text\",\"text\":\":x: ${{ github.repository }} - Failed to deploy ${{ github.event.release.tag_name }}${{ github.event.release.prerelease && ' (Pre-Release)' || '' }} :x:\"}},{\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\"Failed to publish package to PyPI\"}}]}"
+      SUCCESS_PAYLOAD: "{\"blocks\":[{\"type\":\"header\",\"text\":{\"type\":\"plain_text\",\"text\":\":airplane: ${{ github.repository }} - Successfully deployed ${{ needs.deploy.outputs.tag }}${{ needs.deploy.outputs.maturity == 'prerelease' && (needs.deploy.outputs.target == 'production' && ' (Pre-Release → production PyPI)' || ' (Pre-Release → test PyPI)') || '' }} :large_green_circle:\"}},{\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\"Package published to ${{ needs.deploy.outputs.target == 'test' && 'test' || 'production' }} PyPI successfully\"}}]}"
+      FAILURE_PAYLOAD: "{\"blocks\":[{\"type\":\"header\",\"text\":{\"type\":\"plain_text\",\"text\":\":x: ${{ github.repository }} - Failed to deploy ${{ needs.deploy.outputs.tag || github.event.release.tag_name || inputs.version }}${{ needs.deploy.outputs.maturity == 'prerelease' && (needs.deploy.outputs.target == 'production' && ' (Pre-Release → production PyPI)' || ' (Pre-Release → test PyPI)') || '' }} :x:\"}},{\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\"Failed to publish package to PyPI\"}}]}"
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,0 @@
-include LICENSE
-include README.rst
-recursive-include automatilib *
-global-exclude __pycache__
-global-exclude *.py[co]

--- a/Makefile
+++ b/Makefile
@@ -32,3 +32,13 @@ lint:
 	uv run ruff check --fix
 	uv run mypy src/i_dot_ai_utilities/ --ignore-missing-imports
 	uv run bandit -ll -r src/i_dot_ai_utilities
+
+# Run the logging module's tests only. Requires no backing services, so works
+# inside the devcontainer (or anywhere without Docker Compose available).
+test-logging:
+	uv run pytest \
+		src/i_dot_ai_utilities/logging \
+		--cov-config=.coveragerc \
+		--cov src/i_dot_ai_utilities/logging \
+		--cov-report term-missing \
+		--cov-fail-under 75

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ When installing the package, the base package comes with only the `logger` modul
 - file_store
 - litellm
 - metrics
-- otel
-- django
+- otel _(pre-release)_
+- django _(pre-release)_
 - all
 
 To install the package, use your package manager of choice:
@@ -26,6 +26,8 @@ uv pip install "i-dot-ai-utilities[all]"
 ```
 
 Replace `[all]` with any extras from the list above, comma separated, or remove entirely to install just the base package.
+
+> ⚠️ **The `otel` and `django` extras are pre-release, use with caution.** They're compatible only with the OpenTelemetry PoC pipeline, not the existing i.AI observability stack. Pass `--pre` (or pin the pre-release version) to install them; a plain `pip install` won't pull a pre-release. `[all]` pulls them in too, so it also needs `--pre` during the pre-release window.
 
 ## Features
 
@@ -71,7 +73,7 @@ The `otel` extra adds an OpenTelemetry bootstrap (`configure_otel` and the frame
 
 The `django` extra adds request-lifecycle middleware: `StructuredLoggingMiddlewareOTel` for per-request structured logging and `DjangoUserIdMiddleware` for authenticated-user attribution.
 
-> ⚠️ **Pre-release, use with caution.** The `otel` and `django` extras ship as a pre-release and are compatible only with the OpenTelemetry PoC pipeline, not the existing i.AI observability stack. Pin the pre-release explicitly (see below); a plain `pip install` won't pull it.
+> ⚠️ **Pre-release, use with caution** (see the [Installation](#installation) note): compatible only with the OpenTelemetry PoC pipeline, not the existing i.AI observability stack.
 
 You can find usage details in the [logging library readme](./src/i_dot_ai_utilities/logging/README.md).
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ When installing the package, the base package comes with only the `logger` modul
 - litellm
 - metrics
 - otel _(pre-release)_
+- otel_django _(pre-release)_
+- otel_fastapi _(pre-release)_
 - django _(pre-release)_
 - all
 
@@ -27,7 +29,7 @@ uv pip install "i-dot-ai-utilities[all]"
 
 Replace `[all]` with any extras from the list above, comma separated, or remove entirely to install just the base package.
 
-> ⚠️ **The `otel` and `django` extras are pre-release, use with caution.** They're compatible only with the OpenTelemetry PoC pipeline, not the existing i.AI observability stack. Pass `--pre` (or pin the pre-release version) to install them; a plain `pip install` won't pull a pre-release. `[all]` pulls them in too, so it also needs `--pre` during the pre-release window.
+> ⚠️ **The `otel`, `otel_django`, `otel_fastapi`, and `django` extras are pre-release, use with caution.** They're compatible only with the OpenTelemetry PoC pipeline, not the existing i.AI observability stack. Pass `--pre` (or pin the pre-release version) to install them; a plain `pip install` won't pull a pre-release. `[all]` pulls them in too, so it also needs `--pre` during the pre-release window.
 
 ## Features
 
@@ -69,9 +71,9 @@ More information on usage and setup can be found in the [litellm library readme]
 
 #### OpenTelemetry & Django middleware
 
-The `otel` extra adds an OpenTelemetry bootstrap (`configure_otel` and the framework helpers `configure_otel_for_django` / `configure_otel_for_fastapi` / `configure_otel_for_lambda`) that wires traces, metrics, and an optional structlog log bridge to an OTLP endpoint, with W3C + AWS X-Ray propagation.
+The `otel` extra adds a framework-agnostic OpenTelemetry bootstrap (`configure_otel` and the framework helpers `configure_otel_for_django` / `configure_otel_for_fastapi` / `configure_otel_for_lambda`) that wires traces, metrics, and an optional structlog log bridge to an OTLP endpoint, with W3C + AWS X-Ray propagation. Add `otel_django` or `otel_fastapi` for the matching auto-instrumentation, so you only pull the instrumentation you actually use.
 
-The `django` extra adds request-lifecycle middleware: `StructuredLoggingMiddlewareOTel` for per-request structured logging and `DjangoUserIdMiddleware` for authenticated-user attribution.
+The `django` extra adds request-lifecycle middleware: `StructuredLoggingMiddlewareOTel` for per-request structured logging and `DjangoUserIdMiddleware` for authenticated-user attribution. For a Django app wanting the full stack, install `[django,otel_django]`.
 
 > ⚠️ **Pre-release, use with caution** (see the [Installation](#installation) note): compatible only with the OpenTelemetry PoC pipeline, not the existing i.AI observability stack.
 
@@ -115,22 +117,22 @@ Notes:
 
 ```bash
 # opt in to pre-releases (resolves the newest rc)
-pip install --pre "i-dot-ai-utilities[django,otel]"
+pip install --pre "i-dot-ai-utilities[django,otel_django]"
 
 # or pin the exact pre-release version
-pip install "i-dot-ai-utilities[django,otel]==0.6.0rc1"
+pip install "i-dot-ai-utilities[django,otel_django]==0.6.0rc1"
 ```
 
 **From Test PyPI** (pre-release → test channel): point your installer at Test PyPI, provide production PyPI as a fallback index so runtime dependencies resolve, and pin the exact **timestamped** version the workflow generated (replace the version as required):
 
 ```bash
-uv pip install --index https://test.pypi.org/simple/ --index-strategy unsafe-best-match "i-dot-ai-utilities[django,otel]==0.1.1rc202506301522"
+uv pip install --index https://test.pypi.org/simple/ --index-strategy unsafe-best-match "i-dot-ai-utilities[django,otel_django]==0.1.1rc202506301522"
 ```
 
 Or with pip:
 
 ```bash
-pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ "i-dot-ai-utilities[django,otel]==0.1.1rc202506301522"
+pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ "i-dot-ai-utilities[django,otel_django]==0.1.1rc202506301522"
 ```
 
 `--pre` alone is not enough for the Test PyPI channel: the package only exists on Test PyPI, so you must also point the installer at that index (and keep production PyPI as a fallback for dependencies).

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ When installing the package, the base package comes with only the `logger` modul
 - file_store
 - litellm
 - metrics
+- otel
+- django
 - all
 
 To install the package, use your package manager of choice:
@@ -63,16 +65,18 @@ As the end-user, you'll have to make sure that the API key issued to you by Lite
 
 More information on usage and setup can be found in the [litellm library readme](./src/i_dot_ai_utilities/litellm/README.md).
 
+#### OpenTelemetry & Django middleware
+
+The `otel` extra adds an OpenTelemetry bootstrap (`configure_otel` and the framework helpers `configure_otel_for_django` / `configure_otel_for_fastapi` / `configure_otel_for_lambda`) that wires traces, metrics, and an optional structlog log bridge to an OTLP endpoint, with W3C + AWS X-Ray propagation.
+
+The `django` extra adds request-lifecycle middleware: `StructuredLoggingMiddlewareOTel` for per-request structured logging and `DjangoUserIdMiddleware` for authenticated-user attribution.
+
+You can find usage details in the [logging library readme](./src/i_dot_ai_utilities/logging/README.md).
+
 ### Future features:
 
-- authentication
 - authorisation
 - vector stores
-
-## Settings
-
-This is where some of the above can be found:
-
 
 ## How to use
 
@@ -90,20 +94,17 @@ Releases must be manually created, after which the specified package version wil
 
 You may release a pre-release tag to the test version of PyPI by specifying the release as a pre-release on creation. This allows for the testing of a tag in a safe environment before merging to main.
 
-To test a pre-release tag, you can follow these steps in a repo of your choice:
-1. Update pyproject.toml:
-```
-[[tool.poetry.source]]
-name = "test-pypi"
-url = "https://test.pypi.org/simple/"
-priority = "supplemental"
-```
-2. Load the specific version into the environment (replacing version number as required)
-```
-poetry add --source test-pypi i-dot-ai-utilities==0.1.1rc202506301522
+To pull a pre-release tag into a consuming repo, point your installer at Test PyPI and pin the exact version (replace the version as required):
+
+```bash
+uv pip install --index https://test.pypi.org/simple/ --index-strategy unsafe-best-match "i-dot-ai-utilities==0.1.1rc202506301522"
 ```
 
+Or with pip:
 
+```bash
+pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ "i-dot-ai-utilities==0.1.1rc202506301522"
+```
 
 ## Licence
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ The `otel` extra adds an OpenTelemetry bootstrap (`configure_otel` and the frame
 
 The `django` extra adds request-lifecycle middleware: `StructuredLoggingMiddlewareOTel` for per-request structured logging and `DjangoUserIdMiddleware` for authenticated-user attribution.
 
+> ⚠️ **Pre-release, use with caution.** The `otel` and `django` extras ship as a pre-release and are compatible only with the OpenTelemetry PoC pipeline, not the existing i.AI observability stack. Pin the pre-release explicitly (see below); a plain `pip install` won't pull it.
+
 You can find usage details in the [logging library readme](./src/i_dot_ai_utilities/logging/README.md).
 
 ### Future features:

--- a/README.md
+++ b/README.md
@@ -94,21 +94,46 @@ When making changes or adding tests, please ensure tests run in isolation, as fa
 
 ### CI/CD & Releases
 
-Releases must be manually created, after which the specified package version will be released to PyPI. As such, release names must adhere to semantic versioning. They must *not* be prefixed with a `v`.
+Package versions are published to PyPI by the `Publish python package` workflow. Version names must adhere to semantic versioning and must *not* be prefixed with a `v`. Merging to `main` does **not** publish anything; publishing is always a deliberate action.
 
-You may release a pre-release tag to the test version of PyPI by specifying the release as a pre-release on creation. This allows for the testing of a tag in a safe environment before merging to main.
+There are three publish channels:
 
-To pull a pre-release tag into a consuming repo, point your installer at Test PyPI and pin the exact version (replace the version as required):
+| Channel | How to trigger | Version stamped | Published to |
+|---|---|---|---|
+| **Stable release** | Create a GitHub Release, **not** marked as a pre-release | bare tag (e.g. `0.6.0`) | production PyPI |
+| **Pre-release → production** | Run the workflow manually (`Actions → Publish python package → Run workflow`) with `pypi=production` and an existing pre-release tag | tag verbatim (e.g. `0.6.0rc1`) | production PyPI |
+| **Pre-release → test** | Create a GitHub Release, marked as a pre-release | `<tag>.<timestamp>` | Test PyPI |
+
+Notes:
+
+- **Manual dispatch is pre-release only.** The workflow rejects a manual `production` publish whose version is not a PEP 440 pre-release (an `rc` / `a` / `b` / `.dev` suffix). Cut stable releases through the GitHub Release flow.
+- **The tag must already exist before a manual dispatch.** The workflow checks out the tag you pass; create and push it first.
+
+#### Installing a pre-release
+
+**From production PyPI** (pre-release → production channel): pip will not resolve a PEP 440 pre-release unless you opt in with `--pre` or pin the exact version, so ordinary consumers stay on the latest stable automatically.
 
 ```bash
-uv pip install --index https://test.pypi.org/simple/ --index-strategy unsafe-best-match "i-dot-ai-utilities==0.1.1rc202506301522"
+# opt in to pre-releases (resolves the newest rc)
+pip install --pre "i-dot-ai-utilities[django,otel]"
+
+# or pin the exact pre-release version
+pip install "i-dot-ai-utilities[django,otel]==0.6.0rc1"
+```
+
+**From Test PyPI** (pre-release → test channel): point your installer at Test PyPI, provide production PyPI as a fallback index so runtime dependencies resolve, and pin the exact **timestamped** version the workflow generated (replace the version as required):
+
+```bash
+uv pip install --index https://test.pypi.org/simple/ --index-strategy unsafe-best-match "i-dot-ai-utilities[django,otel]==0.1.1rc202506301522"
 ```
 
 Or with pip:
 
 ```bash
-pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ "i-dot-ai-utilities==0.1.1rc202506301522"
+pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ "i-dot-ai-utilities[django,otel]==0.1.1rc202506301522"
 ```
+
+`--pre` alone is not enough for the Test PyPI channel: the package only exists on Test PyPI, so you must also point the installer at that index (and keep production PyPI as a fallback for dependencies).
 
 ## Licence
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,27 +77,38 @@ litellm = [
 # Metrics module - No additional dependencies beyond logging
 metrics = []
 
-# Django module - Adds Django integration (DjangoUserIdMiddleware). The
-# Django middleware that handles request lifecycle logging
-# (StructuredLoggingMiddlewareOTel) lives under the [otel] extra; install
-# both extras together: `pip install "i-dot-ai-utilities[django,otel]"`.
+# Django module - Adds Django itself, needed by StructuredLoggingMiddlewareOTel
+# and DjangoUserIdMiddleware (both import real Django). Pair it with the
+# [otel_django] extra for the OTel bootstrap and auto-instrumentation:
+# `pip install "i-dot-ai-utilities[django,otel_django]"`.
 django = [
     "django>=4.2,<6.0",
 ]
 
-# OTel module - OpenTelemetry bootstrap (configure_otel), Django/FastAPI
-# auto-instrumentation, X-Ray ID generator + composite propagator, and
-# StructuredLoggingMiddlewareOTel. Install [django] and/or FastAPI deps
-# alongside as needed. See src/i_dot_ai_utilities/logging/README.md.
+# OTel core - framework-agnostic bootstrap (configure_otel): traces, metrics,
+# OTLP export, and W3C + AWS X-Ray propagation. Add a framework extra
+# (otel_django / otel_fastapi) to auto-instrument that framework, so a
+# consumer only pulls the instrumentation it actually uses.
+# See src/i_dot_ai_utilities/logging/README.md.
 otel = [
     "opentelemetry-api>=1.27",
     "opentelemetry-sdk>=1.27",
     "opentelemetry-exporter-otlp-proto-http>=1.27",
-    "opentelemetry-instrumentation-django>=0.48b0",
-    "opentelemetry-instrumentation-fastapi>=0.48b0",
-    "opentelemetry-instrumentation-asgi>=0.48b0",
     "opentelemetry-propagator-aws-xray>=1.0.1",
     "opentelemetry-sdk-extension-aws>=2.0.0",
+]
+
+# Django auto-instrumentation for configure_otel_for_django. Pair with the
+# [django] extra for Django itself and StructuredLoggingMiddlewareOTel.
+otel_django = [
+    "i-dot-ai-utilities[otel]",
+    "opentelemetry-instrumentation-django>=0.48b0",
+]
+
+# FastAPI auto-instrumentation for configure_otel_for_fastapi.
+otel_fastapi = [
+    "i-dot-ai-utilities[otel]",
+    "opentelemetry-instrumentation-fastapi>=0.48b0",
 ]
 
 # Install all optional modules
@@ -105,7 +116,7 @@ all = [
     "boto3>=1.40.41",
     "boto3-stubs[s3]>=1.40.41",
     "minio>=7.2.15",
-    "litellm>=1.77.1",
+    "litellm==1.79.0",
     "requests>=2.32.3",
     "rapidfuzz>=3.14.1",
     "ecologits>=0.8.2",
@@ -120,7 +131,6 @@ all = [
     "opentelemetry-exporter-otlp-proto-http>=1.27",
     "opentelemetry-instrumentation-django>=0.48b0",
     "opentelemetry-instrumentation-fastapi>=0.48b0",
-    "opentelemetry-instrumentation-asgi>=0.48b0",
     "opentelemetry-propagator-aws-xray>=1.0.1",
     "opentelemetry-sdk-extension-aws>=2.0.0",
 ]
@@ -222,18 +232,14 @@ dev = [
     "types-requests>=2.32.4.20250913",
     "types-setuptools>=80.9.0.20250529",
     "types-urllib3>=1.26.25.14",
-    # OTel packages duplicate the `[otel]` optional-extra list intentionally
-    # so `uv sync` (dev group) alone is sufficient to run the full test
-    # suite. Without these, the OTel-backed middleware tests silently skip
-    # via `pytest.importorskip("opentelemetry")`, making `pytest --cov`
-    # look catastrophically low (see inclusion rationale in commit
-    # history). No production-consumer impact — only the dev group.
+    # Mirrors the otel extras (core + both framework instrumentations) so
+    # `uv sync` alone runs the full suite; without them the OTel middleware
+    # tests skip via `pytest.importorskip` and coverage reads far too low.
     "opentelemetry-api>=1.27",
     "opentelemetry-sdk>=1.27",
     "opentelemetry-exporter-otlp-proto-http>=1.27",
     "opentelemetry-instrumentation-django>=0.48b0",
     "opentelemetry-instrumentation-fastapi>=0.48b0",
-    "opentelemetry-instrumentation-asgi>=0.48b0",
     "opentelemetry-propagator-aws-xray>=1.0.1",
     "opentelemetry-sdk-extension-aws>=2.0.0",
     "fastapi>=0.115",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,29 @@ litellm = [
 # Metrics module - No additional dependencies beyond logging
 metrics = []
 
+# Django module - Adds Django integration (DjangoUserIdMiddleware). The
+# Django middleware that handles request lifecycle logging
+# (StructuredLoggingMiddlewareOTel) lives under the [otel] extra; install
+# both extras together: `pip install "i-dot-ai-utilities[django,otel]"`.
+django = [
+    "django>=4.2,<6.0",
+]
+
+# OTel module - OpenTelemetry bootstrap (configure_otel), Django/FastAPI
+# auto-instrumentation, X-Ray ID generator + composite propagator, and
+# StructuredLoggingMiddlewareOTel. Install [django] and/or FastAPI deps
+# alongside as needed. See src/i_dot_ai_utilities/logging/README.md.
+otel = [
+    "opentelemetry-api>=1.27",
+    "opentelemetry-sdk>=1.27",
+    "opentelemetry-exporter-otlp-proto-http>=1.27",
+    "opentelemetry-instrumentation-django>=0.48b0",
+    "opentelemetry-instrumentation-fastapi>=0.48b0",
+    "opentelemetry-instrumentation-asgi>=0.48b0",
+    "opentelemetry-propagator-aws-xray>=1.0.1",
+    "opentelemetry-sdk-extension-aws>=2.0.0",
+]
+
 # Install all optional modules
 all = [
     "boto3>=1.40.41",
@@ -90,6 +113,16 @@ all = [
     "google-cloud-storage>=3.3.1",
     "azure-core>=1.35.1",
     "azure-storage-blob>=12.26.0",
+    "grpcio-status>=1.76.0",
+    "django>=4.2,<6.0",
+    "opentelemetry-api>=1.27",
+    "opentelemetry-sdk>=1.27",
+    "opentelemetry-exporter-otlp-proto-http>=1.27",
+    "opentelemetry-instrumentation-django>=0.48b0",
+    "opentelemetry-instrumentation-fastapi>=0.48b0",
+    "opentelemetry-instrumentation-asgi>=0.48b0",
+    "opentelemetry-propagator-aws-xray>=1.0.1",
+    "opentelemetry-sdk-extension-aws>=2.0.0",
 ]
 
 [tool.mypy]
@@ -179,6 +212,7 @@ line-ending = "auto"
 [dependency-groups]
 dev = [
     "bandit>=1.8.3",
+    "django>=4.2,<6.0",
     "mypy>=1.15.0",
     "pre-commit>=4.2.0",
     "pytest>=8.3.5",
@@ -188,6 +222,22 @@ dev = [
     "types-requests>=2.32.4.20250913",
     "types-setuptools>=80.9.0.20250529",
     "types-urllib3>=1.26.25.14",
+    # OTel packages duplicate the `[otel]` optional-extra list intentionally
+    # so `uv sync` (dev group) alone is sufficient to run the full test
+    # suite. Without these, the OTel-backed middleware tests silently skip
+    # via `pytest.importorskip("opentelemetry")`, making `pytest --cov`
+    # look catastrophically low (see inclusion rationale in commit
+    # history). No production-consumer impact — only the dev group.
+    "opentelemetry-api>=1.27",
+    "opentelemetry-sdk>=1.27",
+    "opentelemetry-exporter-otlp-proto-http>=1.27",
+    "opentelemetry-instrumentation-django>=0.48b0",
+    "opentelemetry-instrumentation-fastapi>=0.48b0",
+    "opentelemetry-instrumentation-asgi>=0.48b0",
+    "opentelemetry-propagator-aws-xray>=1.0.1",
+    "opentelemetry-sdk-extension-aws>=2.0.0",
+    "fastapi>=0.115",
+    "httpx>=0.27",
 ]
 
 [tool.hatch.build]
@@ -206,5 +256,8 @@ filterwarnings = [
     "ignore::UserWarning:pydantic.*",
     "ignore::pydantic.warnings.PydanticDeprecatedSince20",
     "ignore:.*Expected.*fields but got.*:UserWarning",
-    "ignore:.*The `dict` method is deprecated.*:pydantic.warnings.PydanticDeprecatedSince20"
+    "ignore:.*The `dict` method is deprecated.*:pydantic.warnings.PydanticDeprecatedSince20",
+    # The OTel SDK's own API->SDK LogRecord conversion re-passes trace_id/span_id
+    # positionally and trips its deprecation warning, even when callers use `context`.
+    "ignore:LogRecord init with .*is deprecated:UserWarning:opentelemetry.sdk._logs._internal"
 ]

--- a/src/i_dot_ai_utilities/logging/README.md
+++ b/src/i_dot_ai_utilities/logging/README.md
@@ -188,6 +188,8 @@ Trace correlation on log records comes from a structlog processor reading the ac
 pip install --pre "i-dot-ai-utilities[django,otel]"
 ```
 
+> **Pre-release channels:** this OTel/Django functionality is opt-in and only compatible with our new observability stack — not the existing one. The command above works when the pre-release was published to **production PyPI**. If it was published to **Test PyPI** instead, `--pre` alone is not enough: you must also point the installer at Test PyPI (with a production fallback index for dependencies) and pin the exact timestamped version. See [CI/CD & Releases](../../../README.md#cicd--releases) in the root README for the full per-channel install commands.
+
 **Configure OTel once at startup** (`wsgi.py`, `asgi.py`, or an `AppConfig.ready()`):
 
 ```python

--- a/src/i_dot_ai_utilities/logging/README.md
+++ b/src/i_dot_ai_utilities/logging/README.md
@@ -89,6 +89,8 @@ async def do_the_thing(request: Request):
     ...
 ```
 
+Django consumers should not need to call `refresh_context()` manually, since the `StructuredLoggingMiddlewareOTel` handles it per request (see below).
+
 <br>
 
 ***
@@ -135,11 +137,13 @@ The above example would extract information from the FastAPI request object (que
 Each Context Enricher object accepts a `type` and `object`. `type` is a `ContextEnrichmentType` enum ([see here](./types/enrichment_types.py) for accepted values). `object` is the Input Object to pass into the logger for context extraction - see the table below for further details.
 
 The following context enrichers are available for use:
+
 | Name | Input Object | Extracted Fields |
 |---------|-------------------------------------------------------------------------------------------------------|----------------------------------------------------------------|
-| FastAPI / Starlette | [Request Object](httpsd:'\[]:?PO-//fastapi.tiangolo.com/advanced/using-request-directly/#details-about-the-request-object) | See [FastApiRequestMetadata](./types/fastapi_enrichment_schema.py#31) |
+| FastAPI / Starlette | [Request Object](https://fastapi.tiangolo.com/advanced/using-request-directly/#details-about-the-request-object) | See [FastApiRequestMetadata](./types/fastapi_enrichment_schema.py#31) |
 | Lambda  | [Lambda Context Object](https://docs.aws.amazon.com/lambda/latest/dg/python-context.html) | See [LambdaContextMetadata](./types/lambda_enrichment_schema.py) |
 
+Django consumers do **not** use a `ContextEnrichmentType`; HTTP request attributes live on OpenTelemetry spans via the Django middleware described in the next section.
 
 <br>
 
@@ -163,3 +167,244 @@ async def login(request: Request):
     ...
 ```
 Fields added in this manner will be indexed and searchable in the downstream logging stack.
+
+<br>
+
+***
+
+<br>
+
+## Django Structured Logging Middleware
+
+An OpenTelemetry-backed Django middleware that automates per-request context refresh and request/response lifecycle logging. Eliminates the need for manual `refresh_context()` calls in every view.
+
+HTTP-request attribute extraction (method / path / route / status code / user agent / client address) is delegated to `opentelemetry-instrumentation-django`, which creates a server span per request whose attributes carry those values. The middleware itself keeps only the log-lifecycle concerns that cannot live on a span: `request_started` / `request_completed` / `request_failed` events, `duration_ms`, status-driven log level, per-hop `request_id`, exclusions, header allowlist, and scope ownership.
+
+Trace correlation on log records comes from a structlog processor reading the active span on **every** event (not just the three lifecycle events), so any `logger.info(...)` inside a view automatically gets `trace_id` / `span_id` / `trace_flags`.
+
+**Install** (both optional extras are required):
+
+```
+pip install "i-dot-ai-utilities[django,otel]"
+```
+
+**Configure OTel once at startup** (`wsgi.py`, `asgi.py`, or an `AppConfig.ready()`):
+
+```python
+from i_dot_ai_utilities.logging._otel import configure_otel_for_django
+
+configure_otel_for_django(service_name="my-service")
+```
+
+By default spans are exported to stdout via `ConsoleSpanExporter` - useful during local development. Pass a real exporter for production:
+
+```python
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+
+configure_otel_for_django(
+    service_name="my-service",
+    span_exporter=OTLPSpanExporter(endpoint="https://otel-collector.example/v1/traces"),
+)
+```
+
+**AWS / Phase 2 environment variables**
+
+| Variable | Purpose |
+|:---|:---|
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Collector HTTP base (e.g. `http://nlb:4318`) |
+| `OTEL_REQUIRE_ENDPOINT` | Set `1` so missing endpoint raises (no silent console export) |
+| `OTEL_EXPORTER_OTLP_HEADERS` | Comma-separated `key=value` (bearer: `Authorization=Bearer …`). Applied to the trace, metric, and log exporters alike |
+
+After constructing `StructuredLogger`, call `ensure_structlog_otel_processors()` so trace/OTLP log processors survive logger reconfiguration. For Lambda/Batch use `configure_otel_for_lambda` and `force_flush_otel()` before exit.
+
+If you forget to call `configure_otel_for_django` at startup, `StructuredLoggingMiddlewareOTel` emits a loud one-shot WARNING at worker boot (`structured_logging_middleware_otel_tracer_provider_missing`) pointing straight at the fix, so the degraded "no trace ids on logs" state is visible immediately rather than showing up as silent absence.
+
+**Wire into `settings.MIDDLEWARE`**. Place it after `SecurityMiddleware` and `AuthenticationMiddleware`, but before application-specific middleware so timing and logging wrap as much of the request lifecycle as possible:
+
+```python
+MIDDLEWARE = [
+    "django.middleware.security.SecurityMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "i_dot_ai_utilities.logging.middleware.django_otel.StructuredLoggingMiddlewareOTel",
+    # ... your other middleware
+]
+```
+
+`DjangoInstrumentor` inserts its own middleware at the front of the chain automatically; do not add it manually.
+
+### Wiring the trace-context structlog processor
+
+`configure_otel_for_django` can insert the processor into your structlog chain for you:
+
+```python
+import structlog
+from i_dot_ai_utilities.logging._otel import configure_otel_for_django
+
+processors = [
+    structlog.contextvars.merge_contextvars,
+    structlog.processors.add_log_level,
+    structlog.processors.JSONRenderer(),
+]
+configure_otel_for_django(
+    service_name="my-service",
+    structlog_processors=processors,  # Mutated in place.
+)
+structlog.configure(processors=processors)
+```
+
+Or wire it yourself using the standalone helper:
+
+```python
+from i_dot_ai_utilities.logging._otel import otel_trace_context_processor
+
+processors = [
+    structlog.contextvars.merge_contextvars,
+    structlog.processors.add_log_level,
+    otel_trace_context_processor,          # <- before the renderer
+    structlog.processors.JSONRenderer(),
+]
+```
+
+### Settings
+
+All settings are optional. The middleware ships with sensible defaults and uses `getattr(settings, ...)` with fallbacks, so you can add them only when you want to override behaviour.
+
+| Setting | Type | Default | Purpose |
+|---|---|---|---|
+| `I_DOT_AI_LOGGER` | logger object \| zero-arg callable | Bare `structlog.get_logger(__name__)` wrapped for the five-method contract | The logger the middleware writes through. **Dotted import strings are NOT accepted** (security finding A4; closes a boot-time arbitrary-import attack surface). Import your logger in `settings.py` and assign it directly, or pass a zero-arg factory. |
+| `I_DOT_AI_LOGGING_MIDDLEWARE_ENABLED` | `bool` | `True` | Set to `False` to disable. The middleware then raises `MiddlewareNotUsed` cleanly at startup. |
+| `I_DOT_AI_LOGGING_EXCLUDED_PREFIXES` | iterable of `str` | Health-check prefixes (see below) | Paths whose prefix matches are skipped entirely; no log events. |
+| `I_DOT_AI_LOGGING_EXCLUDED_REGEXES` | iterable of `str` \| `re.Pattern` | `()` | Additional regex-based exclusions, compiled once at startup. |
+| `I_DOT_AI_LOGGING_HEADER_ALLOWLIST` | iterable of `str` | `()` | Header names to bind to the log context (truncated to 512 chars). Explicit allowlist only, never a denylist. A hard-coded denylist (`Authorization`, `Cookie`, `Set-Cookie`, `Proxy-Authorization`, `X-CSRFToken`, `WWW-Authenticate`, `X-API-Key`) is always applied on top; names on the denylist are silently filtered out of the allowlist and a warning is emitted at startup. |
+
+**Default excluded prefixes** (skipping all high-volume health probes):
+
+- `/health/`
+- `/healthz`
+- `/api/health/`
+- `/api/health/live`
+- `/api/health/ready`
+
+### Example configuration
+
+```python
+# settings.py
+from myapp.logging import build_logger  # imported in your own code, no dotted string
+
+I_DOT_AI_LOGGER = build_logger()  # or: = build_logger  (zero-arg callable)
+I_DOT_AI_LOGGING_EXCLUDED_PREFIXES = (
+    "/healthz",
+    "/api/internal/",
+)
+I_DOT_AI_LOGGING_HEADER_ALLOWLIST = ("X-Tenant-ID",)
+```
+
+### Emitted log events
+
+| Event | When | Level |
+|---|---|---|
+| `structured_logging_middleware_otel_active` | Once per worker process at startup | `info` |
+| `structured_logging_middleware_otel_forbidden_headers_rejected` | At startup iff `I_DOT_AI_LOGGING_HEADER_ALLOWLIST` contained forbidden names that were scrubbed | `warning` |
+| `structured_logging_middleware_otel_tracer_provider_missing` | At startup iff no SDK `TracerProvider` is installed (i.e. `configure_otel_for_django` was not called) | `warning` |
+| `request_started` | Entering the view chain (non-excluded paths) | `info` |
+| `request_completed` | View returned normally, OR raised `Http404` (404 is ordinary traffic, not a failure) | `info` (2xx/3xx), `warning` (4xx incl. `Http404`), `error` (5xx) |
+| `request_failed` | View raised any unhandled exception other than `Http404` | `error` |
+
+Exceptions are logged with full traceback via `logger.exception(...)` then re-raised with a bare `raise`, preserving the original traceback for Sentry / DRF / the debug toolbar. `Http404` is carved out per constitution Art. 46: WARNING, status 404, `request_completed` event name, no traceback (it's a control-flow signal, not a crash).
+
+### Log record schema
+
+The schema is deliberately narrow. HTTP request context lives on the OTel span, not the log line. Every event also carries `logging_schema_version = "1.0"` so consumers can detect breaking changes.
+
+| Field | Source | Type | Notes |
+|---|---|---|---|
+| `logging_schema_version` | middleware | `str` | Always `"1.0"` in this release |
+| `http.response.status_code` | middleware | `int` | Captured after the view returns. Synthesised to `500` on unhandled exception, `404` on `Http404` |
+| `error.type` | middleware | `str`, optional | Status code string (e.g. `"404"`, `"500"`) on 4xx/5xx responses and `Http404`. Fully-qualified exception class name (e.g. `"builtins.RuntimeError"`) on the unhandled-exception path. Absent on 2xx/3xx. Per OTel HTTP semconv note 4 |
+| `exception.type` | middleware | `str`, optional | `type(exc).__name__` on `request_failed` and on the `Http404`-induced `request_completed` |
+| `http.request.header.*` | middleware | `str` | Only for headers explicitly in `I_DOT_AI_LOGGING_HEADER_ALLOWLIST`; lowercased, hyphens to underscores. Length-capped at 512 chars |
+| `duration_ms` | middleware | `int` | `time.monotonic()` delta, clamped to >= 0 |
+| `request_id` | middleware | `str` | **Always** a fresh per-hop UUID4 hex (32 chars). Distinct from `trace_id` and from any inbound correlation id |
+| `upstream_request_id` | middleware | `str`, optional | Inbound `X-Request-ID` preserved verbatim when present and charset-valid (RFC 3986 unreserved + common base64 chars). Length-capped at 200 chars. Absent when no inbound header or when the inbound value fails charset validation (security finding A3: blocks log-injection via attacker-chosen identifiers) |
+| `trace_id` | structlog processor | `str`, optional | 32-hex active trace id; absent outside a span |
+| `span_id` | structlog processor | `str`, optional | 16-hex active span id; absent outside a span |
+| `trace_flags` | structlog processor | `str`, optional | 2-hex active trace flags; absent outside a span |
+
+### What's on the span, not the log record
+
+The following attributes live on the OTel server span and are queryable via your trace backend, NOT on the log line:
+
+- `http.request.method`, `url.scheme`, `url.path`, `url.query`, `server.address`
+- `user_agent.original`, `client.address`, `http.request.header.x_forwarded_for`
+- `http.route`, `django.url_name`
+
+If your OpenSearch / Loki dashboards need to filter on any of these, shift those queries to your trace backend and join log records on `trace_id`.
+
+### Request-ID semantics
+
+Constitution Art. 32 requires a fresh per-hop `request_id` UUID4, distinct from any inbound correlation value. This middleware honours that contract:
+
+- `request_id` is **always** a freshly generated UUID4 hex, minted at request entry.
+- An inbound `X-Request-ID` header, when present and charset-valid, is preserved verbatim in a separate `upstream_request_id` field (length-capped at 200 chars). The two fields never collide.
+- Charset-invalid inbound values (whitespace, control characters, quoting characters) are rejected silently; the `upstream_request_id` field is simply omitted. This is security finding A3: accepting an attacker-chosen `X-Request-ID` verbatim into log context enables log-injection and log-search hijack.
+- `X-Request-ID` is NEVER used as the trace id or fed to the OTel propagator. Trace context comes from `traceparent` / `X-Amzn-Trace-Id` via the composite propagator.
+
+### Trace-header handling
+
+OTel's composite propagator (W3C Trace Context + AWS X-Ray, installed by `configure_otel_for_django`) handles inbound headers. **W3C `traceparent` wins when both `traceparent` and `X-Amzn-Trace-Id` are present.** `X-Request-ID` is not a trace context and is never fed to the propagator - it is bound to the `upstream_request_id` log field when charset-valid.
+
+### Security
+
+- `FORBIDDEN_HEADER_NAMES` (Authorization, Cookie, Set-Cookie, Proxy-Authorization, X-CSRFToken, X-CSRF-Token, WWW-Authenticate, X-API-Key) are refused even when listed in `I_DOT_AI_LOGGING_HEADER_ALLOWLIST`. A `structured_logging_middleware_otel_forbidden_headers_rejected` WARNING is emitted at startup when this happens so mis-configuration is visible.
+- `I_DOT_AI_LOGGER` accepts logger objects and zero-arg callables - never dotted-import strings (finding A4).
+- Inbound `X-Request-ID` is charset-validated (RFC 3986 unreserved + common base64 chars) before being bound as `upstream_request_id`. Attacker-controlled values containing whitespace, control bytes, or quoting characters are dropped silently (finding A3: blocks log-injection / log-search hijack).
+- Scope ownership (`REQUEST_SCOPE_OWNER_MIDDLEWARE`) guards against mid-request `refresh_context()` calls from views or helpers silently de-correlating the audit trail.
+- Malformed settings (`I_DOT_AI_LOGGING_EXCLUDED_PREFIXES` non-iterable, `I_DOT_AI_LOGGING_EXCLUDED_REGEXES` with invalid patterns, `I_DOT_AI_LOGGING_HEADER_ALLOWLIST` non-iterable) raise `django.core.exceptions.ImproperlyConfigured` at boot with a specific message; no bare `TypeError` / `re.error` / `AttributeError` crashes on the first request. Non-string entries inside an otherwise valid allowlist are dropped silently so copy-paste bugs don't brick startup.
+
+### Notes
+
+- Sync-only. `sync_capable = True`, `async_capable = False`.
+- Thread-safe under Gunicorn sync / gthread workers via `structlog.contextvars`.
+- `configure_otel_for_django` is idempotent - safe to call during both `wsgi.py` and `asgi.py` initialisation.
+
+<br>
+
+***
+
+<br>
+
+## Binding `user.id` to log records
+
+The Django middleware deliberately does **not** extract the authenticated user. OpenTelemetry's Django instrumentation does not expose it as a span attribute, and baking the extraction into the main middleware would re-entangle this library with Django's auth model.
+
+A thin companion middleware, `DjangoUserIdMiddleware`, does this one job safely:
+
+```python
+MIDDLEWARE = [
+    "django.middleware.security.SecurityMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "i_dot_ai_utilities.logging.middleware.django_otel.StructuredLoggingMiddlewareOTel",
+    "i_dot_ai_utilities.logging.middleware.django_user_id.DjangoUserIdMiddleware",
+    # ... your other middleware
+]
+```
+
+Ordering matters:
+
+1. **After `AuthenticationMiddleware`**, so `request.user` exists.
+2. **After `StructuredLoggingMiddlewareOTel`**, so the request scope is already active and `set_context_field("user.id", ...)` lands on the correct per-request context.
+
+### Safety guarantees
+
+The middleware lifts the hardening that used to live inside the deleted `DjangoEnricher`:
+
+- **No database query from an unhydrated `SimpleLazyObject`** (security finding FI-5). Django's auth middleware assigns a `SimpleLazyObject` to `request.user`; touching `.pk` before it hydrates triggers a `User.objects.get(...)` query. Observability code must never issue such a query, since it masks database outages from the very logs that would diagnose them. The middleware detects the unhydrated state structurally (`_wrapped` sentinel) without forcing evaluation.
+- **Database errors surface as WARNINGs**, not silent drops. If reading `request.user.is_authenticated` or `request.user.pk` raises a Django `DatabaseError` / `OperationalError` / `InterfaceError` / `ProgrammingError` / `IntegrityError`, the middleware emits a WARNING naming the failing access and continues; the request is unaffected but operators see the outage.
+- Anonymous users produce no `user.id` field at all (not a falsy value), so `has(user.id)` queries discriminate cleanly.
+- The OTel `enduser.*` namespace was deprecated in v1.24; only the opaque primary key is emitted, never email / username / other PII.
+
+### Settings
+
+`DjangoUserIdMiddleware` honours the same `I_DOT_AI_LOGGER` and `I_DOT_AI_LOGGING_MIDDLEWARE_ENABLED` settings as `StructuredLoggingMiddlewareOTel`; no additional configuration is required.

--- a/src/i_dot_ai_utilities/logging/README.md
+++ b/src/i_dot_ai_utilities/logging/README.md
@@ -182,10 +182,10 @@ HTTP-request attribute extraction (method / path / route / status code / user ag
 
 Trace correlation on log records comes from a structlog processor reading the active span on **every** event (not just the three lifecycle events), so any `logger.info(...)` inside a view automatically gets `trace_id` / `span_id` / `trace_flags`.
 
-**Install** (both optional extras are required). This ships as a pre-release, so pass `--pre` or pin the pre-release version; a plain `pip install` skips pre-releases:
+**Install** (`otel_django` brings the OTel bootstrap and Django auto-instrumentation; `django` brings Django itself and the middleware). This ships as a pre-release, so pass `--pre` or pin the pre-release version; a plain `pip install` skips pre-releases:
 
 ```
-pip install --pre "i-dot-ai-utilities[django,otel]"
+pip install --pre "i-dot-ai-utilities[django,otel_django]"
 ```
 
 > **Pre-release channels:** this OTel/Django functionality is opt-in and only compatible with our new observability stack — not the existing one. The command above works when the pre-release was published to **production PyPI**. If it was published to **Test PyPI** instead, `--pre` alone is not enough: you must also point the installer at Test PyPI (with a production fallback index for dependencies) and pin the exact timestamped version. See [CI/CD & Releases](../../../README.md#cicd--releases) in the root README for the full per-channel install commands.

--- a/src/i_dot_ai_utilities/logging/README.md
+++ b/src/i_dot_ai_utilities/logging/README.md
@@ -182,10 +182,10 @@ HTTP-request attribute extraction (method / path / route / status code / user ag
 
 Trace correlation on log records comes from a structlog processor reading the active span on **every** event (not just the three lifecycle events), so any `logger.info(...)` inside a view automatically gets `trace_id` / `span_id` / `trace_flags`.
 
-**Install** (both optional extras are required):
+**Install** (both optional extras are required). This ships as a pre-release, so pass `--pre` or pin the pre-release version; a plain `pip install` skips pre-releases:
 
 ```
-pip install "i-dot-ai-utilities[django,otel]"
+pip install --pre "i-dot-ai-utilities[django,otel]"
 ```
 
 **Configure OTel once at startup** (`wsgi.py`, `asgi.py`, or an `AppConfig.ready()`):
@@ -272,7 +272,7 @@ All settings are optional. The middleware ships with sensible defaults and uses 
 
 | Setting | Type | Default | Purpose |
 |---|---|---|---|
-| `I_DOT_AI_LOGGER` | logger object \| zero-arg callable | Bare `structlog.get_logger(__name__)` wrapped for the five-method contract | The logger the middleware writes through. **Dotted import strings are NOT accepted** (security finding A4; closes a boot-time arbitrary-import attack surface). Import your logger in `settings.py` and assign it directly, or pass a zero-arg factory. |
+| `I_DOT_AI_LOGGER` | logger object \| zero-arg callable | Bare `structlog.get_logger(__name__)` wrapped for the five-method contract | The logger the middleware writes through. **Dotted import strings are NOT accepted** (closes a boot-time arbitrary-import attack surface). Import your logger in `settings.py` and assign it directly, or pass a zero-arg factory. |
 | `I_DOT_AI_LOGGING_MIDDLEWARE_ENABLED` | `bool` | `True` | Set to `False` to disable. The middleware then raises `MiddlewareNotUsed` cleanly at startup. |
 | `I_DOT_AI_LOGGING_EXCLUDED_PREFIXES` | iterable of `str` | Health-check prefixes (see below) | Paths whose prefix matches are skipped entirely; no log events. |
 | `I_DOT_AI_LOGGING_EXCLUDED_REGEXES` | iterable of `str` \| `re.Pattern` | `()` | Additional regex-based exclusions, compiled once at startup. |
@@ -311,7 +311,7 @@ I_DOT_AI_LOGGING_HEADER_ALLOWLIST = ("X-Tenant-ID",)
 | `request_completed` | View returned normally, OR raised `Http404` (404 is ordinary traffic, not a failure) | `info` (2xx/3xx), `warning` (4xx incl. `Http404`), `error` (5xx) |
 | `request_failed` | View raised any unhandled exception other than `Http404` | `error` |
 
-Exceptions are logged with full traceback via `logger.exception(...)` then re-raised with a bare `raise`, preserving the original traceback for Sentry / DRF / the debug toolbar. `Http404` is carved out per constitution Art. 46: WARNING, status 404, `request_completed` event name, no traceback (it's a control-flow signal, not a crash).
+Exceptions are logged with full traceback via `logger.exception(...)` then re-raised with a bare `raise`, preserving the original traceback for Sentry / DRF / the debug toolbar. `Http404` is carved out: WARNING, status 404, `request_completed` event name, no traceback (it's a control-flow signal, not a crash).
 
 ### Log record schema
 
@@ -326,7 +326,7 @@ The schema is deliberately narrow. HTTP request context lives on the OTel span, 
 | `http.request.header.*` | middleware | `str` | Only for headers explicitly in `I_DOT_AI_LOGGING_HEADER_ALLOWLIST`; lowercased, hyphens to underscores. Length-capped at 512 chars |
 | `duration_ms` | middleware | `int` | `time.monotonic()` delta, clamped to >= 0 |
 | `request_id` | middleware | `str` | **Always** a fresh per-hop UUID4 hex (32 chars). Distinct from `trace_id` and from any inbound correlation id |
-| `upstream_request_id` | middleware | `str`, optional | Inbound `X-Request-ID` preserved verbatim when present and charset-valid (RFC 3986 unreserved + common base64 chars). Length-capped at 200 chars. Absent when no inbound header or when the inbound value fails charset validation (security finding A3: blocks log-injection via attacker-chosen identifiers) |
+| `upstream_request_id` | middleware | `str`, optional | Inbound `X-Request-ID` preserved verbatim when present and charset-valid (RFC 3986 unreserved + common base64 chars). Length-capped at 200 chars. Absent when no inbound header or when the inbound value fails charset validation (blocks log-injection via attacker-chosen identifiers) |
 | `trace_id` | structlog processor | `str`, optional | 32-hex active trace id; absent outside a span |
 | `span_id` | structlog processor | `str`, optional | 16-hex active span id; absent outside a span |
 | `trace_flags` | structlog processor | `str`, optional | 2-hex active trace flags; absent outside a span |
@@ -343,11 +343,11 @@ If your OpenSearch / Loki dashboards need to filter on any of these, shift those
 
 ### Request-ID semantics
 
-Constitution Art. 32 requires a fresh per-hop `request_id` UUID4, distinct from any inbound correlation value. This middleware honours that contract:
+The middleware mints a fresh per-hop `request_id` UUID4, distinct from any inbound correlation value:
 
 - `request_id` is **always** a freshly generated UUID4 hex, minted at request entry.
 - An inbound `X-Request-ID` header, when present and charset-valid, is preserved verbatim in a separate `upstream_request_id` field (length-capped at 200 chars). The two fields never collide.
-- Charset-invalid inbound values (whitespace, control characters, quoting characters) are rejected silently; the `upstream_request_id` field is simply omitted. This is security finding A3: accepting an attacker-chosen `X-Request-ID` verbatim into log context enables log-injection and log-search hijack.
+- Charset-invalid inbound values (whitespace, control characters, quoting characters) are rejected silently; the `upstream_request_id` field is simply omitted. Accepting an attacker-chosen `X-Request-ID` verbatim into log context enables log-injection and log-search hijack.
 - `X-Request-ID` is NEVER used as the trace id or fed to the OTel propagator. Trace context comes from `traceparent` / `X-Amzn-Trace-Id` via the composite propagator.
 
 ### Trace-header handling
@@ -400,7 +400,7 @@ Ordering matters:
 
 The middleware lifts the hardening that used to live inside the deleted `DjangoEnricher`:
 
-- **No database query from an unhydrated `SimpleLazyObject`** (security finding FI-5). Django's auth middleware assigns a `SimpleLazyObject` to `request.user`; touching `.pk` before it hydrates triggers a `User.objects.get(...)` query. Observability code must never issue such a query, since it masks database outages from the very logs that would diagnose them. The middleware detects the unhydrated state structurally (`_wrapped` sentinel) without forcing evaluation.
+- **No database query from an unhydrated `SimpleLazyObject`**. Django's auth middleware assigns a `SimpleLazyObject` to `request.user`; touching `.pk` before it hydrates triggers a `User.objects.get(...)` query. Observability code must never issue such a query, since it masks database outages from the very logs that would diagnose them. The middleware detects the unhydrated state structurally (`_wrapped` sentinel) without forcing evaluation.
 - **Database errors surface as WARNINGs**, not silent drops. If reading `request.user.is_authenticated` or `request.user.pk` raises a Django `DatabaseError` / `OperationalError` / `InterfaceError` / `ProgrammingError` / `IntegrityError`, the middleware emits a WARNING naming the failing access and continues; the request is unaffected but operators see the outage.
 - Anonymous users produce no `user.id` field at all (not a falsy value), so `has(user.id)` queries discriminate cleanly.
 - The OTel `enduser.*` namespace was deprecated in v1.24; only the opaque primary key is emitted, never email / username / other PII.

--- a/src/i_dot_ai_utilities/logging/__tests__/_otel/conftest.py
+++ b/src/i_dot_ai_utilities/logging/__tests__/_otel/conftest.py
@@ -1,0 +1,80 @@
+# mypy: disable-error-code="no-untyped-def"
+"""Shared fixtures for the `_otel` subpackage tests.
+
+Provides:
+
+- ``in_memory_exporter``: fresh ``InMemorySpanExporter`` per test.
+- ``tracer_provider_with_memory_exporter``: :class:`TracerProvider`
+  wired to the in-memory exporter and made global for the duration of
+  the test. Uses a ``SimpleSpanProcessor`` so exported spans are
+  readable synchronously after each test request.
+- ``reset_otel_state`` (autouse): restores global OTel state
+  (propagator, tracer provider, DjangoInstrumentor activation) after
+  every test so tests are independent.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+pytest.importorskip("opentelemetry")
+
+from opentelemetry.propagate import get_global_textmap, set_global_textmap
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+
+@pytest.fixture
+def in_memory_exporter() -> InMemorySpanExporter:
+    return InMemorySpanExporter()
+
+
+@pytest.fixture
+def tracer_provider_with_memory_exporter(
+    in_memory_exporter: InMemorySpanExporter,
+) -> TracerProvider:
+    provider = TracerProvider(resource=Resource.create({"service.name": "test-service"}))
+    # SimpleSpanProcessor exports synchronously on span-end; tests can
+    # read spans immediately after the request has finished.
+    provider.add_span_processor(SimpleSpanProcessor(in_memory_exporter))
+    return provider
+
+
+@pytest.fixture(autouse=True)
+def reset_otel_state() -> Generator[None, None, None]:
+    """Best-effort OTel state restoration between tests.
+
+    Restores the global textmap after each test so propagator-
+    installation tests don't bleed into sibling tests.
+
+    We deliberately do NOT call ``DjangoInstrumentor().uninstrument()``
+    here. The ``middleware/test_django_otel.py`` module calls
+    ``configure_otel_for_django`` at module-load time to wire a shared
+    ``InMemorySpanExporter``; an aggressive teardown in this conftest
+    would undo that wiring when the module test order puts ``_otel``
+    tests first. Tests that genuinely need to reset the instrumentor
+    should do so explicitly.
+    """
+    prev_textmap = get_global_textmap()
+    try:
+        yield
+    finally:
+        set_global_textmap(prev_textmap)
+        # configure_otel is idempotent in production: once configured it
+        # returns the installed provider instead of rebuilding. Tests call it
+        # repeatedly with different env/resources, so clear just the config
+        # gate (not the instrumentor flags, which the note above protects) to
+        # force a fresh resource per test.
+        from i_dot_ai_utilities.logging._otel import setup as _otel_setup  # noqa: PLC0415
+
+        _otel_setup._configured = False  # noqa: SLF001 - reset module state between tests
+        _otel_setup._tracer_provider = None  # noqa: SLF001 - reset module state between tests

--- a/src/i_dot_ai_utilities/logging/__tests__/_otel/test_configure_otel.py
+++ b/src/i_dot_ai_utilities/logging/__tests__/_otel/test_configure_otel.py
@@ -1,0 +1,102 @@
+# mypy: disable-error-code="no-untyped-def"
+"""Additional tests for framework-neutral ``configure_otel``."""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("opentelemetry")
+
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from i_dot_ai_utilities.logging._otel.setup import (
+    _otlp_exporter_kwargs,
+    _reset_for_tests,
+    configure_otel,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_flags():
+    _reset_for_tests()
+    yield
+    _reset_for_tests()
+
+
+class TestConfigureOTel:
+    def test_returns_tracer_provider(self):
+        provider = configure_otel(
+            service_name="neutral-svc",
+            span_exporter=InMemorySpanExporter(),
+            install_global_propagator=False,
+            enable_metrics=False,
+            enable_log_bridge=False,
+        )
+        assert isinstance(provider, TracerProvider)
+
+    def test_resource_includes_semconv_environment_name(self, monkeypatch):
+        monkeypatch.setenv("ENVIRONMENT", "sandbox")
+        provider = configure_otel(
+            service_name="neutral-svc",
+            span_exporter=InMemorySpanExporter(),
+            install_global_propagator=False,
+            enable_metrics=False,
+            enable_log_bridge=False,
+        )
+        attrs = dict(provider.resource.attributes)
+        assert attrs.get("deployment.environment.name") == "sandbox"
+        assert "deployment.environment" not in attrs
+
+    def test_require_endpoint_raises_when_missing(self, monkeypatch):
+        monkeypatch.setenv("OTEL_REQUIRE_ENDPOINT", "1")
+        monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+        with pytest.raises(RuntimeError, match="OTEL_REQUIRE_ENDPOINT"):
+            configure_otel(
+                service_name="aws-svc",
+                install_global_propagator=False,
+                enable_metrics=False,
+                enable_log_bridge=False,
+            )
+
+
+class TestOtlpExporterKwargs:
+    """All three signals must share endpoint and header handling.
+
+    Regression guard: headers were previously applied to traces only, so an
+    authenticated collector would accept spans but reject logs and metrics.
+    """
+
+    SIGNALS = ("/v1/traces", "/v1/metrics", "/v1/logs")
+
+    def test_returns_none_without_endpoint(self, monkeypatch):
+        monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+        for signal in self.SIGNALS:
+            assert _otlp_exporter_kwargs(signal) is None
+
+    def test_all_signals_receive_parsed_headers(self, monkeypatch):
+        monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://collector:4318")
+        monkeypatch.setenv("OTEL_EXPORTER_OTLP_HEADERS", "Authorization=Bearer tkn, x-tenant=iai")
+        for signal in self.SIGNALS:
+            kwargs = _otlp_exporter_kwargs(signal)
+            assert kwargs["endpoint"] == f"http://collector:4318{signal}"
+            assert kwargs["headers"] == {
+                "Authorization": "Bearer tkn",
+                "x-tenant": "iai",
+            }
+
+    def test_headers_omitted_when_env_unset(self, monkeypatch):
+        monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://collector:4318")
+        monkeypatch.delenv("OTEL_EXPORTER_OTLP_HEADERS", raising=False)
+        for signal in self.SIGNALS:
+            assert "headers" not in _otlp_exporter_kwargs(signal)
+
+    def test_endpoint_suffix_is_not_duplicated(self, monkeypatch):
+        monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://collector:4318/v1/traces")
+        kwargs = _otlp_exporter_kwargs("/v1/traces")
+        assert kwargs["endpoint"] == "http://collector:4318/v1/traces"
+
+    def test_trailing_slash_endpoint_is_normalised(self, monkeypatch):
+        monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://collector:4318/")
+        kwargs = _otlp_exporter_kwargs("/v1/logs")
+        assert kwargs["endpoint"] == "http://collector:4318/v1/logs"

--- a/src/i_dot_ai_utilities/logging/__tests__/_otel/test_otlp_log_processor.py
+++ b/src/i_dot_ai_utilities/logging/__tests__/_otel/test_otlp_log_processor.py
@@ -1,0 +1,87 @@
+"""Tests for the OTLP log emitter structlog processor."""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("opentelemetry")
+
+from opentelemetry._logs import set_logger_provider
+from opentelemetry.sdk._logs import LoggerProvider
+from opentelemetry.sdk._logs.export import (
+    InMemoryLogExporter,
+    SimpleLogRecordProcessor,
+)
+from opentelemetry.sdk.trace import TracerProvider
+
+from i_dot_ai_utilities.logging._otel.otlp_log_processor import (
+    otel_otlp_log_emitter_processor,
+)
+
+# OTel refuses to replace the global LoggerProvider once set, so install one
+# shared provider for the module and clear the exporter between tests.
+# SimpleLogRecordProcessor exports synchronously on emit, so tests can read the
+# record back immediately.
+_SHARED_EXPORTER = InMemoryLogExporter()
+_SHARED_PROVIDER = LoggerProvider()
+_SHARED_PROVIDER.add_log_record_processor(SimpleLogRecordProcessor(_SHARED_EXPORTER))
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _install_logger_provider() -> None:
+    set_logger_provider(_SHARED_PROVIDER)
+
+
+@pytest.fixture
+def log_exporter() -> InMemoryLogExporter:
+    _SHARED_EXPORTER.clear()
+    return _SHARED_EXPORTER
+
+
+def test_returns_event_dict_unchanged() -> None:
+    event = {"event": "hello", "level": "info", "user_id": 1}
+    out = otel_otlp_log_emitter_processor(None, "info", event)
+    assert out is event
+    assert out["event"] == "hello"
+    assert out["user_id"] == 1
+
+
+def test_emits_record_with_body_severity_and_attributes(log_exporter: InMemoryLogExporter) -> None:
+    event = {
+        "event": "hello",
+        "level": "info",
+        "timestamp": "2026-07-29T12:00:00Z",
+        "poc_run_id": "poc-ts-001",
+    }
+
+    otel_otlp_log_emitter_processor(None, "info", event)
+
+    logs = log_exporter.get_finished_logs()
+    assert len(logs) == 1
+    record = logs[0].log_record
+    assert record.body == "hello"
+    assert record.severity_text == "INFO"
+    assert record.attributes is not None
+    # The structlog ``timestamp`` field is metadata, not a log attribute.
+    assert dict(record.attributes) == {"poc_run_id": "poc-ts-001"}
+
+
+def test_sets_nonzero_timestamp(log_exporter: InMemoryLogExporter) -> None:
+    # A zero/unset timestamp maps to OTLP time_unix_nano=0, which surfaces as
+    # @timestamp=1970 in OpenSearch, so the processor must always set it.
+    otel_otlp_log_emitter_processor(None, "info", {"event": "hi", "level": "info"})
+
+    record = log_exporter.get_finished_logs()[0].log_record
+    assert isinstance(record.timestamp, int)
+    assert record.timestamp > 0
+
+
+def test_correlates_with_active_span(log_exporter: InMemoryLogExporter) -> None:
+    tracer = TracerProvider().get_tracer(__name__)
+    with tracer.start_as_current_span("work"):
+        otel_otlp_log_emitter_processor(None, "info", {"event": "hi", "level": "info"})
+
+    record = log_exporter.get_finished_logs()[0].log_record
+    # Emitting with the active context lets the SDK stamp trace correlation.
+    assert record.trace_id != 0
+    assert record.span_id != 0

--- a/src/i_dot_ai_utilities/logging/__tests__/_otel/test_propagators.py
+++ b/src/i_dot_ai_utilities/logging/__tests__/_otel/test_propagators.py
@@ -1,0 +1,154 @@
+# mypy: disable-error-code="no-untyped-def"
+"""Tests for ``_otel.propagators.build_composite_propagator``."""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("opentelemetry")
+
+from opentelemetry import trace
+from opentelemetry.propagate import set_global_textmap
+from opentelemetry.propagators.aws import AwsXRayPropagator
+from opentelemetry.propagators.composite import CompositePropagator
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.trace.propagation.tracecontext import (
+    TraceContextTextMapPropagator,
+)
+
+from i_dot_ai_utilities.logging._otel.propagators import (
+    build_composite_propagator,
+)
+
+# W3C-formatted traceparent (sampled).
+TRACEPARENT = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+W3C_TRACE_ID_INT = 0x0AF7651916CD43DD8448EB211C80319C
+W3C_SPAN_ID_INT = 0xB7AD6B7169203331
+
+# X-Ray header format: `Root=1-<32hex>;Parent=<16hex>;Sampled=1`.
+XRAY_HEADER = "Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1"
+XRAY_TRACE_ID_INT = 0x5759E988BD862E3FE1BE46A994272793
+XRAY_SPAN_ID_INT = 0x53995C3F42CD8AD8
+
+
+def _install_provider() -> None:
+    # Attach a non-None tracer provider once per process so
+    # ``SpanContext.extract`` survives into ``trace.get_current_span``.
+    # The SDK refuses to replace an existing provider; rely on that
+    # behaviour rather than forcing a swap.
+    current = trace.get_tracer_provider()
+    # ``ProxyTracerProvider`` is the uninitialised default. If we've
+    # already set a real one, leave it in place.
+    if type(current).__name__ == "ProxyTracerProvider":
+        trace.set_tracer_provider(TracerProvider())
+
+
+def test_returns_composite_with_two_members_in_order():
+    prop = build_composite_propagator()
+    assert isinstance(prop, CompositePropagator)
+
+    # The CompositePropagator exposes members via its private attribute
+    # in the SDK. Assert on behaviour rather than attribute name; run
+    # ``inject`` and check both headers appear.
+    carrier: dict[str, str] = {}
+    _install_provider()
+    set_global_textmap(prop)
+    tracer = trace.get_tracer(__name__)
+    with tracer.start_as_current_span("probe"):
+        from opentelemetry.propagate import inject  # noqa: PLC0415
+
+        inject(carrier)
+    # W3C always injects ``traceparent``; X-Ray injects
+    # ``X-Amzn-Trace-Id``.
+    assert "traceparent" in carrier
+    assert "X-Amzn-Trace-Id" in carrier
+
+
+def test_fields_property_covers_both_propagator_vocabularies():
+    prop = build_composite_propagator()
+    fields = set(prop.fields)
+    # Each sub-propagator contributes its own field names.
+    assert fields >= set(TraceContextTextMapPropagator().fields)
+    assert fields >= set(AwsXRayPropagator().fields)
+
+
+def test_extract_prefers_w3c_when_both_headers_present():
+    prop = build_composite_propagator()
+    _install_provider()
+    set_global_textmap(prop)
+
+    carrier = {
+        "traceparent": TRACEPARENT,
+        "X-Amzn-Trace-Id": XRAY_HEADER,
+    }
+    from opentelemetry.propagate import extract  # noqa: PLC0415
+
+    ctx = extract(carrier)
+    span = trace.get_current_span(ctx)
+    sc = span.get_span_context()
+    assert sc.is_valid
+    assert sc.trace_id == W3C_TRACE_ID_INT
+    assert sc.span_id == W3C_SPAN_ID_INT
+
+
+def test_extract_falls_back_to_xray_when_no_w3c_header():
+    prop = build_composite_propagator()
+    _install_provider()
+    set_global_textmap(prop)
+
+    from opentelemetry.propagate import extract  # noqa: PLC0415
+
+    ctx = extract({"X-Amzn-Trace-Id": XRAY_HEADER})
+    span = trace.get_current_span(ctx)
+    sc = span.get_span_context()
+    assert sc.is_valid
+    assert sc.trace_id == XRAY_TRACE_ID_INT
+    assert sc.span_id == XRAY_SPAN_ID_INT
+
+
+def test_extract_produces_invalid_context_when_no_recognised_headers():
+    prop = build_composite_propagator()
+    _install_provider()
+    set_global_textmap(prop)
+
+    from opentelemetry.propagate import extract  # noqa: PLC0415
+
+    ctx = extract({"X-Random-Header": "irrelevant"})
+    span = trace.get_current_span(ctx)
+    sc = span.get_span_context()
+    assert not sc.is_valid
+
+
+def test_malformed_traceparent_falls_back_to_xray():
+    """A broken ``traceparent`` must not stop X-Ray from being parsed."""
+    prop = build_composite_propagator()
+    _install_provider()
+    set_global_textmap(prop)
+
+    from opentelemetry.propagate import extract  # noqa: PLC0415
+
+    ctx = extract(
+        {
+            # Version `ff` is explicitly invalid per W3C.
+            "traceparent": "ff-" + "0" * 32 + "-" + "0" * 16 + "-00",
+            "X-Amzn-Trace-Id": XRAY_HEADER,
+        }
+    )
+    span = trace.get_current_span(ctx)
+    sc = span.get_span_context()
+    assert sc.is_valid
+    assert sc.trace_id == XRAY_TRACE_ID_INT
+
+
+def test_propagator_does_not_touch_x_request_id():
+    """``X-Request-ID`` is log-correlation only, not a trace context."""
+    prop = build_composite_propagator()
+    _install_provider()
+    set_global_textmap(prop)
+
+    from opentelemetry.propagate import extract  # noqa: PLC0415
+
+    ctx = extract({"X-Request-ID": "abc123"})
+    span = trace.get_current_span(ctx)
+    sc = span.get_span_context()
+    assert not sc.is_valid

--- a/src/i_dot_ai_utilities/logging/__tests__/_otel/test_setup.py
+++ b/src/i_dot_ai_utilities/logging/__tests__/_otel/test_setup.py
@@ -1,0 +1,271 @@
+# mypy: disable-error-code="no-untyped-def"
+"""Tests for ``_otel.setup.configure_otel_for_django`` and helpers.
+
+Important constraint: OpenTelemetry's ``trace.set_tracer_provider`` logs
+``Overriding of current TracerProvider is not allowed`` on the second
+call in the same process. These tests avoid that by doing provider-level
+assertions via the returned object rather than via
+``trace.get_tracer_provider()``.
+
+Django is required because ``setup.configure_otel_for_django`` calls
+``DjangoInstrumentor().instrument()``; we configure Django settings
+inside the conftest/fixture path rather than here so tests can still be
+collected when Django is absent.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+django = pytest.importorskip("django")
+pytest.importorskip("opentelemetry")
+
+from django.conf import settings as django_settings  # type: ignore[import-untyped]  # noqa: E402
+
+if not django_settings.configured:
+    django_settings.configure(
+        DEBUG=False,
+        ALLOWED_HOSTS=["*"],
+        DATABASES={},
+        INSTALLED_APPS=[],
+        ROOT_URLCONF=__name__,
+        MIDDLEWARE=[],
+        SECRET_KEY="test-secret-not-for-production",
+        USE_TZ=True,
+    )
+    import django as _django  # type: ignore[import-untyped]
+
+    _django.setup()
+
+from opentelemetry.propagate import get_global_textmap  # noqa: E402
+from opentelemetry.propagators.composite import CompositePropagator  # noqa: E402
+from opentelemetry.sdk.trace import TracerProvider  # noqa: E402
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (  # noqa: E402
+    InMemorySpanExporter,
+)
+
+from i_dot_ai_utilities.logging._otel.otlp_log_processor import (  # noqa: E402
+    otel_otlp_log_emitter_processor,
+)
+from i_dot_ai_utilities.logging._otel.setup import (  # noqa: E402
+    configure_otel_for_django,
+    insert_trace_processor,
+)
+from i_dot_ai_utilities.logging._otel.structlog_processor import (  # noqa: E402
+    otel_trace_context_processor,
+)
+
+
+class TestInsertTraceProcessor:
+    def test_empty_list_gets_processors_appended(self):
+        result = insert_trace_processor([])
+        assert result == [otel_trace_context_processor, otel_otlp_log_emitter_processor]
+
+    def test_processors_inserted_before_renderer_in_order(self):
+        # Simulate a structlog chain: merge_contextvars, add_log_level, JSONRenderer.
+        def merge_contextvars(*_args, **_kwargs):
+            return {}
+
+        def add_log_level(*_args, **_kwargs):
+            return {}
+
+        def json_renderer(*_args, **_kwargs):
+            return "{}"
+
+        chain = [merge_contextvars, add_log_level, json_renderer]
+        result = insert_trace_processor(chain)
+
+        # Trace context precedes the log emitter so OTLP logs carry trace ids;
+        # both stay before the terminal renderer.
+        assert result[0] is merge_contextvars
+        assert result[1] is add_log_level
+        assert result[2] is otel_trace_context_processor
+        assert result[3] is otel_otlp_log_emitter_processor
+        assert result[4] is json_renderer
+
+    def test_idempotent_when_processor_already_present(self):
+        def _placeholder(*_args, **_kwargs):
+            return "x"
+
+        chain: list = [otel_trace_context_processor, _placeholder]
+        result = insert_trace_processor(chain)
+        # Exactly one occurrence of the processor.
+        assert result.count(otel_trace_context_processor) == 1
+
+    def test_does_not_mutate_input_list(self):
+        def _placeholder(*_args, **_kwargs):
+            return "x"
+
+        chain: list = [_placeholder]
+        original_len = len(chain)
+        insert_trace_processor(chain)
+        assert len(chain) == original_len
+
+
+class TestConfigureOTelForDjango:
+    def test_passing_tracer_provider_routes_spans_to_its_exporter(
+        self, tracer_provider_with_memory_exporter, in_memory_exporter
+    ):
+        configure_otel_for_django(
+            service_name="svc",
+            tracer_provider=tracer_provider_with_memory_exporter,
+            install_global_propagator=False,
+        )
+        tracer = tracer_provider_with_memory_exporter.get_tracer(__name__)
+        with tracer.start_as_current_span("work"):
+            pass
+
+        spans = in_memory_exporter.get_finished_spans()
+        assert len(spans) == 1
+        assert spans[0].name == "work"
+
+    def test_install_global_propagator_true_replaces_textmap(self, tracer_provider_with_memory_exporter):
+        configure_otel_for_django(
+            service_name="svc",
+            tracer_provider=tracer_provider_with_memory_exporter,
+            install_global_propagator=True,
+        )
+        textmap = get_global_textmap()
+        assert isinstance(textmap, CompositePropagator)
+
+    def test_install_global_propagator_false_leaves_textmap_alone(self, tracer_provider_with_memory_exporter):
+        before = get_global_textmap()
+        configure_otel_for_django(
+            service_name="svc",
+            tracer_provider=tracer_provider_with_memory_exporter,
+            install_global_propagator=False,
+        )
+        after = get_global_textmap()
+        assert after is before
+
+    def test_structlog_processors_list_receives_trace_processor(self, tracer_provider_with_memory_exporter):
+        def _placeholder(*_args, **_kwargs):
+            return "x"
+
+        processors: list = [_placeholder]
+        configure_otel_for_django(
+            service_name="svc",
+            tracer_provider=tracer_provider_with_memory_exporter,
+            install_global_propagator=False,
+            structlog_processors=processors,
+        )
+        assert otel_trace_context_processor in processors
+
+    def test_structlog_processors_none_is_fine(self, tracer_provider_with_memory_exporter):
+        # Should not raise.
+        provider = configure_otel_for_django(
+            service_name="svc",
+            tracer_provider=tracer_provider_with_memory_exporter,
+            install_global_propagator=False,
+            structlog_processors=None,
+        )
+        assert provider is tracer_provider_with_memory_exporter
+
+    def test_default_exporter_path_does_not_raise(self):
+        """Smoke test: when no provider is passed, setup builds a default
+        provider and returns it without raising. We inject an
+        ``InMemorySpanExporter`` to avoid pytest-vs-ConsoleSpanExporter
+        shutdown races leaving noise in the teardown log."""
+        provider = configure_otel_for_django(
+            service_name="svc",
+            span_exporter=InMemorySpanExporter(),
+            install_global_propagator=False,
+        )
+        assert isinstance(provider, TracerProvider)
+        # Tracer usable.
+        tracer = provider.get_tracer(__name__)
+        with tracer.start_as_current_span("probe"):
+            pass
+
+
+class TestBuildResourceEnvVars:
+    """``_build_resource`` reads ``APP_VERSION`` and ``ENVIRONMENT`` from
+    the process environment and binds them as OTel resource attributes.
+
+    These branches are easy to break and drive production observability:
+    ``service.version`` gates vendor-side "version compare" views and
+    ``deployment.environment.name`` is the primary filter across every
+    Grafana / Tempo dashboard. We pin the behaviour directly here rather
+    than only through integration coverage.
+    """
+
+    def _resource_attrs(self, provider: TracerProvider) -> dict:
+        """Return the provider's Resource attributes as a plain dict.
+
+        The Resource API exposes a read-only mapping; converting makes
+        the ``in`` / ``not in`` assertions below concise.
+        """
+        return dict(provider.resource.attributes)
+
+    def test_app_version_env_var_becomes_service_version(self, monkeypatch):
+        monkeypatch.setenv("APP_VERSION", "1.2.3")
+        monkeypatch.delenv("ENVIRONMENT", raising=False)
+
+        provider = configure_otel_for_django(
+            service_name="svc",
+            span_exporter=InMemorySpanExporter(),
+            install_global_propagator=False,
+        )
+        attrs = self._resource_attrs(provider)
+        assert attrs.get("service.version") == "1.2.3"
+        assert attrs.get("service.name") == "svc"
+
+    def test_environment_env_var_becomes_deployment_environment(self, monkeypatch):
+        monkeypatch.delenv("APP_VERSION", raising=False)
+        monkeypatch.setenv("ENVIRONMENT", "prod")
+
+        provider = configure_otel_for_django(
+            service_name="svc",
+            span_exporter=InMemorySpanExporter(),
+            install_global_propagator=False,
+        )
+        attrs = self._resource_attrs(provider)
+        assert attrs.get("deployment.environment.name") == "prod"
+
+    def test_both_env_vars_bound_when_set(self, monkeypatch):
+        monkeypatch.setenv("APP_VERSION", "4.5.6")
+        monkeypatch.setenv("ENVIRONMENT", "staging")
+
+        provider = configure_otel_for_django(
+            service_name="svc",
+            span_exporter=InMemorySpanExporter(),
+            install_global_propagator=False,
+        )
+        attrs = self._resource_attrs(provider)
+        assert attrs.get("service.version") == "4.5.6"
+        assert attrs.get("deployment.environment.name") == "staging"
+
+    def test_missing_env_vars_omit_attributes_rather_than_binding_empty(self, monkeypatch):
+        """Absent env vars MUST NOT be bound as empty-string attributes, since
+        downstream queries doing ``deployment.environment.name != ""`` would
+        produce false positives. ``_build_resource`` explicitly checks
+        truthiness before binding.
+        """
+        monkeypatch.delenv("APP_VERSION", raising=False)
+        monkeypatch.delenv("ENVIRONMENT", raising=False)
+
+        provider = configure_otel_for_django(
+            service_name="svc",
+            span_exporter=InMemorySpanExporter(),
+            install_global_propagator=False,
+        )
+        attrs = self._resource_attrs(provider)
+        assert "service.version" not in attrs
+        assert "deployment.environment.name" not in attrs
+
+    def test_empty_string_env_vars_are_treated_as_unset(self, monkeypatch):
+        """``os.environ["APP_VERSION"] = ""`` should NOT produce
+        ``service.version=""``. The helper uses ``if version:`` which
+        treats empty strings as falsy, same for ``ENVIRONMENT``.
+        """
+        monkeypatch.setenv("APP_VERSION", "")
+        monkeypatch.setenv("ENVIRONMENT", "")
+
+        provider = configure_otel_for_django(
+            service_name="svc",
+            span_exporter=InMemorySpanExporter(),
+            install_global_propagator=False,
+        )
+        attrs = self._resource_attrs(provider)
+        assert "service.version" not in attrs
+        assert "deployment.environment.name" not in attrs

--- a/src/i_dot_ai_utilities/logging/__tests__/_otel/test_structlog_processor.py
+++ b/src/i_dot_ai_utilities/logging/__tests__/_otel/test_structlog_processor.py
@@ -1,0 +1,105 @@
+# mypy: disable-error-code="no-untyped-def"
+"""Tests for ``_otel.structlog_processor.otel_trace_context_processor``."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+pytest.importorskip("opentelemetry")
+
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+
+from i_dot_ai_utilities.logging._otel.structlog_processor import (
+    otel_trace_context_processor,
+)
+
+
+def _ensure_provider() -> None:
+    current = trace.get_tracer_provider()
+    if type(current).__name__ == "ProxyTracerProvider":
+        trace.set_tracer_provider(TracerProvider())
+
+
+def test_injects_trace_span_and_flags_inside_span():
+    _ensure_provider()
+    tracer = trace.get_tracer(__name__)
+    event_dict: dict[str, Any] = {"event": "hello"}
+    with tracer.start_as_current_span("probe"):
+        result = otel_trace_context_processor(None, "info", event_dict)
+
+    assert "trace_id" in result
+    assert "span_id" in result
+    assert "trace_flags" in result
+    # Formats: 32 hex, 16 hex, 2 hex, all lowercase.
+    assert len(result["trace_id"]) == 32
+    assert len(result["span_id"]) == 16
+    assert len(result["trace_flags"]) == 2
+    assert result["trace_id"] == result["trace_id"].lower()
+    assert result["span_id"] == result["span_id"].lower()
+
+
+def test_omits_keys_when_no_active_span():
+    event_dict: dict[str, Any] = {"event": "hello"}
+    result = otel_trace_context_processor(None, "info", event_dict)
+    assert "trace_id" not in result
+    assert "span_id" not in result
+    assert "trace_flags" not in result
+
+
+def test_returns_same_dict_object():
+    """Structlog processors are expected to mutate and return in place."""
+    event_dict: dict[str, Any] = {"event": "hello"}
+    result = otel_trace_context_processor(None, "info", event_dict)
+    assert result is event_dict
+
+
+def test_preserves_existing_keys():
+    _ensure_provider()
+    tracer = trace.get_tracer(__name__)
+    event_dict: dict[str, Any] = {"event": "hello", "other_key": "value"}
+    with tracer.start_as_current_span("probe"):
+        result = otel_trace_context_processor(None, "info", event_dict)
+    assert result["event"] == "hello"
+    assert result["other_key"] == "value"
+    assert "trace_id" in result
+
+
+def test_existing_trace_id_left_untouched_when_no_span():
+    """If a caller pre-set ``trace_id`` and there is no active span, the
+    processor must not blow it away."""
+    event_dict: dict[str, Any] = {"event": "hello", "trace_id": "pre-existing"}
+    result = otel_trace_context_processor(None, "info", event_dict)
+    assert result["trace_id"] == "pre-existing"
+
+
+def test_broken_span_context_swallowed():
+    """A misbehaving span must never take the log line down."""
+
+    class _BrokenSpan:
+        def get_span_context(self) -> Any:
+            msg = "boom"
+            raise RuntimeError(msg)
+
+    event_dict: dict[str, Any] = {"event": "hello"}
+    with patch(
+        "i_dot_ai_utilities.logging._otel.structlog_processor.trace.get_current_span",
+        return_value=_BrokenSpan(),
+    ):
+        result = otel_trace_context_processor(None, "info", event_dict)
+
+    # No keys injected, no exception raised, original event preserved.
+    assert "trace_id" not in result
+    assert result["event"] == "hello"
+
+
+@pytest.mark.parametrize("method_name", ["debug", "info", "warning", "error", "exception"])
+def test_works_for_every_method_name(method_name):
+    _ensure_provider()
+    tracer = trace.get_tracer(__name__)
+    with tracer.start_as_current_span("probe"):
+        result = otel_trace_context_processor(None, method_name, {"event": "x"})
+    assert "trace_id" in result

--- a/src/i_dot_ai_utilities/logging/__tests__/conftest.py
+++ b/src/i_dot_ai_utilities/logging/__tests__/conftest.py
@@ -1,0 +1,16 @@
+# mypy: disable-error-code="no-untyped-def"
+"""Shared pytest fixtures for the logging module tests.
+
+Autouse fixture clears ``structlog.contextvars`` before and after every test
+so bound context cannot leak between tests running on the same thread.
+"""
+
+import pytest
+import structlog
+
+
+@pytest.fixture(autouse=True)
+def _clear_structlog_contextvars():
+    structlog.contextvars.clear_contextvars()
+    yield
+    structlog.contextvars.clear_contextvars()

--- a/src/i_dot_ai_utilities/logging/__tests__/middleware/test_django_otel.py
+++ b/src/i_dot_ai_utilities/logging/__tests__/middleware/test_django_otel.py
@@ -1,0 +1,1225 @@
+# mypy: disable-error-code="no-untyped-def"
+"""Integration tests for ``StructuredLoggingMiddlewareOTel``.
+
+Mirrors ``test_middleware_django.py`` in style: a ``RecordingLogger``
+double captures everything the middleware does, so assertions are made
+on structured fields without needing structlog configuration.
+
+Span-level assertions use an ``InMemorySpanExporter`` wired via
+:func:`configure_otel_for_django` in the module-level setup. Because
+OpenTelemetry refuses to replace a global tracer provider once set, the
+provider is configured exactly once per process.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+import pytest
+
+django = pytest.importorskip("django")
+pytest.importorskip("opentelemetry")
+
+from django.conf import settings as django_settings  # type: ignore[import-untyped]  # noqa: E402
+
+if not django_settings.configured:
+    django_settings.configure(
+        DEBUG=False,
+        ALLOWED_HOSTS=["*"],
+        DATABASES={},
+        INSTALLED_APPS=[],
+        ROOT_URLCONF=__name__,
+        MIDDLEWARE=[],
+        SECRET_KEY="test-secret-not-for-production",
+        USE_TZ=True,
+    )
+    import django as _django  # type: ignore[import-untyped]
+
+    _django.setup()
+
+import structlog  # noqa: E402
+from django.core.exceptions import (  # type: ignore[import-untyped]  # noqa: E402
+    ImproperlyConfigured,
+    MiddlewareNotUsed,
+)
+from django.http import Http404, HttpResponse  # type: ignore[import-untyped]  # noqa: E402
+from django.test import RequestFactory  # type: ignore[import-untyped]  # noqa: E402
+from opentelemetry.sdk.resources import Resource  # noqa: E402
+from opentelemetry.sdk.trace import TracerProvider  # noqa: E402
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor  # noqa: E402
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (  # noqa: E402
+    InMemorySpanExporter,
+)
+
+from i_dot_ai_utilities.logging._otel.setup import (  # noqa: E402
+    _reset_for_tests,
+    configure_otel_for_django,
+)
+from i_dot_ai_utilities.logging.middleware.django_otel import (  # noqa: E402
+    StructuredLoggingMiddlewareOTel,
+)
+from i_dot_ai_utilities.logging.structured_logger import (  # noqa: E402
+    _request_scope_owner,
+)
+
+urlpatterns: list = []
+
+UUID_HEX_RE = re.compile(r"^[0-9a-f]{32}$")
+
+
+# ---------------------------------------------------------------------------
+# Module-level OTel setup.
+#
+# OpenTelemetry refuses to replace a TracerProvider once ``set_tracer_provider``
+# has been called, so we configure exactly once for the whole test module and
+# share the in-memory exporter via a module-global.
+# ---------------------------------------------------------------------------
+
+
+_SHARED_EXPORTER = InMemorySpanExporter()
+_SHARED_PROVIDER = TracerProvider(resource=Resource.create({"service.name": "otel-mw-tests"}))
+_SHARED_PROVIDER.add_span_processor(SimpleSpanProcessor(_SHARED_EXPORTER))
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _configure_otel_for_module():
+    """(Re)instrument Django against the shared exporter for this module.
+
+    Sibling ``_otel`` tests toggle the module-level instrumentation flags and
+    globally uninstrument Django. We reset first so the idempotency guard in
+    ``configure_otel_for_django`` doesn't skip re-instrumenting, then wire the
+    DjangoInstrumentor back to our shared provider. Running at test time (not
+    import time) makes this robust to whatever order pytest collects modules.
+    """
+    _reset_for_tests()
+    configure_otel_for_django(
+        service_name="otel-mw-tests",
+        tracer_provider=_SHARED_PROVIDER,
+        install_global_propagator=True,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clear_exporter():
+    _SHARED_EXPORTER.clear()
+    yield
+    _SHARED_EXPORTER.clear()
+
+
+@pytest.fixture(autouse=True)
+def _clear_structlog_contextvars():
+    """Art. 57: ensure no structlog context bleeds between tests."""
+    structlog.contextvars.clear_contextvars()
+    yield
+    structlog.contextvars.clear_contextvars()
+
+
+# ---------------------------------------------------------------------------
+# Test double: records every call made by the middleware.
+# ---------------------------------------------------------------------------
+
+
+class RecordingLogger:
+    """Structured-logger double matching ``_StructuredLoggerLike``."""
+
+    def __init__(self) -> None:
+        self.events: list[dict[str, Any]] = []
+        self.context: dict[str, Any] = {}
+        self.refresh_calls: list[tuple[list[Any] | None, str]] = []
+
+    def info(self, message_template: str, **kwargs: Any) -> None:
+        self._record("info", message_template, kwargs)
+
+    def warning(self, message_template: str, **kwargs: Any) -> None:
+        self._record("warning", message_template, kwargs)
+
+    def error(self, message_template: str, **kwargs: Any) -> None:
+        self._record("error", message_template, kwargs)
+
+    def exception(self, message_template: str, **kwargs: Any) -> None:
+        self._record("error", message_template, kwargs, exception=True)
+
+    def set_context_field(self, key: str, value: Any) -> None:
+        self.context[key] = value
+
+    def refresh_context(
+        self,
+        context_enrichers: list[Any] | None = None,
+        scope: str = "manual",
+    ) -> None:
+        self.refresh_calls.append((context_enrichers, scope))
+        # Mirror the real refresh: clear prior context.
+        self.context = {}
+
+    def _record(
+        self,
+        level: str,
+        event: str,
+        kwargs: dict[str, Any],
+        *,
+        exception: bool = False,
+    ) -> None:
+        record = {
+            "log_level": level,
+            "event": event,
+            "exception_captured": exception,
+            **self.context,
+            **kwargs,
+        }
+        self.events.append(record)
+
+    def events_for(self, event: str) -> list[dict[str, Any]]:
+        return [e for e in self.events if e["event"] == event]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def rf() -> RequestFactory:
+    return RequestFactory()
+
+
+@pytest.fixture
+def logger() -> RecordingLogger:
+    return RecordingLogger()
+
+
+@pytest.fixture
+def settings_sandbox():
+    """Restore any attribute changes on ``django.conf.settings``."""
+    snapshot: dict[str, Any] = {}
+    marker = object()
+
+    def apply(**kwargs: Any) -> None:
+        for k, v in kwargs.items():
+            snapshot[k] = getattr(django_settings, k, marker)
+            setattr(django_settings, k, v)
+
+    yield apply
+
+    for k, v in snapshot.items():
+        if v is marker:
+            if hasattr(django_settings, k):
+                delattr(django_settings, k)
+        else:
+            setattr(django_settings, k, v)
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+class TestHappyPath:
+    def test_200_emits_started_and_completed(self, rf, logger, settings_sandbox):
+        settings_sandbox(I_DOT_AI_LOGGER=logger)
+        sentinel = HttpResponse(status=200)
+
+        def get_response(_request):
+            return sentinel
+
+        mw = StructuredLoggingMiddlewareOTel(get_response)
+        result = mw(rf.get("/users"))
+        assert result is sentinel
+
+        started = logger.events_for("request_started")
+        completed = logger.events_for("request_completed")
+        failed = logger.events_for("request_failed")
+        assert len(started) == 1
+        assert len(completed) == 1
+        assert len(failed) == 0
+
+        assert started[0]["log_level"] == "info"
+        assert completed[0]["log_level"] == "info"
+        assert completed[0]["http.response.status_code"] == 200
+        assert isinstance(completed[0]["duration_ms"], int)
+        assert completed[0]["duration_ms"] >= 0
+        # request_id always present; UUID4 hex when no inbound header.
+        assert UUID_HEX_RE.match(completed[0]["request_id"])
+
+    def test_refresh_context_called_with_no_enrichers_and_request_scope(self, rf, logger, settings_sandbox):
+        settings_sandbox(I_DOT_AI_LOGGER=logger)
+        mw = StructuredLoggingMiddlewareOTel(lambda _r: HttpResponse(status=200))
+        mw(rf.get("/anything"))
+
+        # Exactly one refresh_context call, with no enrichers and scope="request".
+        assert len(logger.refresh_calls) == 1
+        enrichers, scope = logger.refresh_calls[0]
+        assert enrichers is None
+        assert scope == "request"
+
+    def test_log_line_does_not_contain_http_fields(self, rf, logger, settings_sandbox):
+        """HTTP context fields belong on the OTel span, not on log records."""
+        settings_sandbox(I_DOT_AI_LOGGER=logger)
+        mw = StructuredLoggingMiddlewareOTel(lambda _r: HttpResponse(status=200))
+        mw(rf.get("/things?foo=bar", HTTP_USER_AGENT="curl/8.0"))
+
+        completed = logger.events_for("request_completed")[0]
+        # None of these fields should be on the log record.
+        forbidden = (
+            "http.request.method",
+            "url.scheme",
+            "url.path",
+            "url.query",
+            "server.address",
+            "user_agent.original",
+            "client.address",
+            "http.route",
+            "django.url_name",
+            "user.id",
+        )
+        for field in forbidden:
+            assert field not in completed, f"{field!r} leaked onto log record"
+
+    def test_span_is_recorded_by_django_instrumentor(self, logger, settings_sandbox):
+        """DjangoInstrumentor creates a server span with HTTP attributes.
+
+        Uses Django's full test client so the request flows through
+        ``BaseHandler``, which is what the instrumentor patches via its
+        own middleware entry added to ``settings.MIDDLEWARE``.
+        ``RequestFactory`` alone bypasses that layer.
+        """
+        from django.http import HttpResponse as _HttpResponse  # noqa: PLC0415
+        from django.test import Client  # noqa: PLC0415
+        from django.urls import path  # noqa: PLC0415
+
+        def _ok(_request):
+            return _HttpResponse(status=200)
+
+        # Preserve the OTel instrumentation middleware added by
+        # DjangoInstrumentor(), it ships as the first entry of
+        # settings.MIDDLEWARE and we must keep it alongside our own.
+        otel_mw = [m for m in django_settings.MIDDLEWARE if "opentelemetry" in m.lower()]
+        settings_sandbox(
+            I_DOT_AI_LOGGER=logger,
+            ROOT_URLCONF=__name__,
+            MIDDLEWARE=[
+                *otel_mw,
+                "i_dot_ai_utilities.logging.middleware.django_otel.StructuredLoggingMiddlewareOTel",
+            ],
+        )
+        global urlpatterns  # noqa: PLW0603 - ROOT_URLCONF points at this module so tests must swap its urlpatterns in and out
+        prev = urlpatterns
+        urlpatterns = [path("users", _ok)]
+        try:
+            client = Client()
+            response = client.get("/users")
+        finally:
+            urlpatterns = prev
+
+        assert response.status_code == 200
+        spans = _SHARED_EXPORTER.get_finished_spans()
+        assert spans, "DjangoInstrumentor did not emit a span"
+        attrs_by_span = [dict(s.attributes or {}) for s in spans]
+        has_http_method = any("http.request.method" in a or "http.method" in a for a in attrs_by_span)
+        assert has_http_method, f"No span carried an HTTP method attribute. Attrs: {attrs_by_span}"
+
+
+# ---------------------------------------------------------------------------
+# Status-driven levels
+# ---------------------------------------------------------------------------
+
+
+class TestStatusLevels:
+    @pytest.mark.parametrize(
+        ("status", "expected_level"),
+        [(200, "info"), (301, "info"), (404, "warning"), (500, "error")],
+    )
+    def test_level_reflects_status(self, status, expected_level, rf, logger, settings_sandbox):
+        settings_sandbox(I_DOT_AI_LOGGER=logger)
+        mw = StructuredLoggingMiddlewareOTel(lambda _r: HttpResponse(status=status))
+        mw(rf.get("/p"))
+
+        completed = logger.events_for("request_completed")
+        assert len(completed) == 1
+        assert completed[0]["log_level"] == expected_level
+        assert completed[0]["http.response.status_code"] == status
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class TestExceptions:
+    def test_view_exception_emits_failed_at_error_and_reraises(self, rf, logger, settings_sandbox):
+        settings_sandbox(I_DOT_AI_LOGGER=logger)
+
+        def boom(_request):
+            msg = "boom"
+            raise RuntimeError(msg)
+
+        mw = StructuredLoggingMiddlewareOTel(boom)
+
+        with pytest.raises(RuntimeError, match="boom"):
+            mw(rf.get("/danger"))
+
+        failed = logger.events_for("request_failed")
+        assert len(failed) == 1
+        assert failed[0]["log_level"] == "error"
+        assert failed[0]["exception_captured"] is True
+        assert failed[0]["exception.type"] == "RuntimeError"
+        assert failed[0]["http.response.status_code"] == 500
+        assert isinstance(failed[0]["duration_ms"], int)
+        assert failed[0]["duration_ms"] >= 0
+
+        # No completed event on failure.
+        assert logger.events_for("request_completed") == []
+
+    def test_process_exception_hook_is_noop(self, rf, logger, settings_sandbox):
+        settings_sandbox(I_DOT_AI_LOGGER=logger)
+        mw = StructuredLoggingMiddlewareOTel(lambda _r: HttpResponse(status=200))
+        events_before = len(logger.events)
+        result = mw.process_exception(rf.get("/"), RuntimeError("nope"))
+        assert result is None
+        # The no-op hook must not produce any new log events.
+        assert len(logger.events) == events_before
+
+
+# ---------------------------------------------------------------------------
+# Exclusions
+# ---------------------------------------------------------------------------
+
+
+class TestExclusions:
+    def test_excluded_prefix_skips_logging_but_calls_view(self, rf, logger, settings_sandbox):
+        settings_sandbox(
+            I_DOT_AI_LOGGER=logger,
+            I_DOT_AI_LOGGING_EXCLUDED_PREFIXES=("/healthz",),
+        )
+        called = {"flag": False}
+
+        def view(_request):
+            called["flag"] = True
+            return HttpResponse(status=200)
+
+        mw = StructuredLoggingMiddlewareOTel(view)
+        mw(rf.get("/healthz/ready"))
+
+        assert called["flag"] is True
+        # No lifecycle events.
+        assert logger.events_for("request_started") == []
+        assert logger.events_for("request_completed") == []
+        assert logger.events_for("request_failed") == []
+
+    def test_excluded_regex_skips_logging(self, rf, logger, settings_sandbox):
+        settings_sandbox(
+            I_DOT_AI_LOGGER=logger,
+            I_DOT_AI_LOGGING_EXCLUDED_REGEXES=(r"^/internal/",),
+        )
+        mw = StructuredLoggingMiddlewareOTel(lambda _r: HttpResponse(status=200))
+        mw(rf.get("/internal/metrics"))
+
+        assert logger.events_for("request_started") == []
+
+
+# ---------------------------------------------------------------------------
+# Header allowlist
+# ---------------------------------------------------------------------------
+
+
+class TestHeaderAllowlist:
+    def test_allowlisted_header_is_captured(self, rf, logger, settings_sandbox):
+        settings_sandbox(
+            I_DOT_AI_LOGGER=logger,
+            I_DOT_AI_LOGGING_HEADER_ALLOWLIST=("X-Tenant-ID",),
+        )
+        mw = StructuredLoggingMiddlewareOTel(lambda _r: HttpResponse(status=200))
+        mw(rf.get("/x", HTTP_X_TENANT_ID="acme"))
+
+        completed = logger.events_for("request_completed")[0]
+        assert completed["http.request.header.x_tenant_id"] == "acme"
+
+    def test_non_allowlisted_header_not_captured(self, rf, logger, settings_sandbox):
+        settings_sandbox(I_DOT_AI_LOGGER=logger)
+        mw = StructuredLoggingMiddlewareOTel(lambda _r: HttpResponse(status=200))
+        mw(rf.get("/x", HTTP_X_SECRET="nope"))
+
+        completed = logger.events_for("request_completed")[0]
+        assert not any(k.startswith("http.request.header.") for k in completed)
+
+    def test_forbidden_header_refused_even_if_allowlisted(self, rf, logger, settings_sandbox):
+        settings_sandbox(
+            I_DOT_AI_LOGGER=logger,
+            I_DOT_AI_LOGGING_HEADER_ALLOWLIST=("Authorization", "X-Tenant-ID"),
+        )
+        mw = StructuredLoggingMiddlewareOTel(lambda _r: HttpResponse(status=200))
+        mw(rf.get("/x", HTTP_AUTHORIZATION="Bearer s3cret", HTTP_X_TENANT_ID="acme"))
+
+        completed = logger.events_for("request_completed")[0]
+        # Authorization must not appear under any spelling.
+        assert "http.request.header.authorization" not in completed
+        # The legitimate header still flows through.
+        assert completed["http.request.header.x_tenant_id"] == "acme"
+
+
+# ---------------------------------------------------------------------------
+# Request ID handling
+# ---------------------------------------------------------------------------
+
+
+class TestRequestId:
+    """Constitution Art. 30 + 32: ``request_id`` is ALWAYS a fresh per-hop
+    UUID4, distinct from any inbound correlation value. Any valid inbound
+    ``X-Request-ID`` is preserved verbatim as ``upstream_request_id``.
+    Charset-invalid or absent inbound values produce no
+    ``upstream_request_id`` key at all (not an empty string).
+    """
+
+    def test_request_id_is_always_fresh_uuid_even_with_inbound_header(self, rf, logger, settings_sandbox):
+        settings_sandbox(I_DOT_AI_LOGGER=logger)
+        mw = StructuredLoggingMiddlewareOTel(lambda _r: HttpResponse(status=200))
+        mw(rf.get("/", HTTP_X_REQUEST_ID="external-id-123"))
+
+        completed = logger.events_for("request_completed")[0]
+        # Fresh UUID4, NOT the inbound value.
+        assert UUID_HEX_RE.match(completed["request_id"])
+        assert completed["request_id"] != "external-id-123"
+        # Inbound preserved in its own field.
+        assert completed["upstream_request_id"] == "external-id-123"
+
+    def test_fresh_uuid_when_no_inbound_header(self, rf, logger, settings_sandbox):
+        settings_sandbox(I_DOT_AI_LOGGER=logger)
+        mw = StructuredLoggingMiddlewareOTel(lambda _r: HttpResponse(status=200))
+        mw(rf.get("/"))
+
+        completed = logger.events_for("request_completed")[0]
+        assert UUID_HEX_RE.match(completed["request_id"])
+        # No inbound header → no upstream_request_id key at all.
+        assert "upstream_request_id" not in completed
+
+    def test_oversized_inbound_id_is_truncated_in_upstream_field(self, rf, logger, settings_sandbox):
+        settings_sandbox(I_DOT_AI_LOGGER=logger)
+        mw = StructuredLoggingMiddlewareOTel(lambda _r: HttpResponse(status=200))
+        mw(rf.get("/", HTTP_X_REQUEST_ID="a" * 1000))
+
+        completed = logger.events_for("request_completed")[0]
+        # MAX_REQUEST_ID is 200 in _limits.py.
+        assert len(completed["upstream_request_id"]) == 200
+        # The locally-minted request_id is unaffected.
+        assert UUID_HEX_RE.match(completed["request_id"])
+
+    @pytest.mark.parametrize(
+        "bad_value",
+        [
+            "has spaces",
+            "has\ttab",
+            "has\x00null",
+            'has"quote',
+            "has'apostrophe",
+            "  ",  # whitespace-only → stripped to empty → rejected
+        ],
+    )
+    def test_charset_invalid_inbound_id_is_rejected_without_upstream_field(
+        self, bad_value, rf, logger, settings_sandbox
+    ):
+        """Security finding A3: charset-invalid X-Request-ID values must
+        NOT be propagated verbatim into log context (log-injection /
+        log-search hijack). The local request_id is still minted cleanly.
+        """
+        settings_sandbox(I_DOT_AI_LOGGER=logger)
+        mw = StructuredLoggingMiddlewareOTel(lambda _r: HttpResponse(status=200))
+        mw(rf.get("/", HTTP_X_REQUEST_ID=bad_value))
+
+        completed = logger.events_for("request_completed")[0]
+        assert "upstream_request_id" not in completed
+        assert UUID_HEX_RE.match(completed["request_id"])
+
+    def test_empty_inbound_header_produces_no_upstream_field(self, rf, logger, settings_sandbox):
+        settings_sandbox(I_DOT_AI_LOGGER=logger)
+        mw = StructuredLoggingMiddlewareOTel(lambda _r: HttpResponse(status=200))
+        mw(rf.get("/", HTTP_X_REQUEST_ID=""))
+
+        completed = logger.events_for("request_completed")[0]
+        assert "upstream_request_id" not in completed
+        assert UUID_HEX_RE.match(completed["request_id"])
+
+    def test_request_id_distinct_across_two_sequential_requests(self, rf, logger, settings_sandbox):
+        """Per-hop identity: two requests through the same middleware
+        instance get two different request_ids even when the inbound
+        header is identical.
+        """
+        settings_sandbox(I_DOT_AI_LOGGER=logger)
+        mw = StructuredLoggingMiddlewareOTel(lambda _r: HttpResponse(status=200))
+        mw(rf.get("/", HTTP_X_REQUEST_ID="upstream-xyz"))
+        first_id = logger.events_for("request_completed")[0]["request_id"]
+
+        mw(rf.get("/", HTTP_X_REQUEST_ID="upstream-xyz"))
+        second_id = logger.events_for("request_completed")[1]["request_id"]
+
+        assert first_id != second_id
+
+
+# ---------------------------------------------------------------------------
+# Scope ownership
+# ---------------------------------------------------------------------------
+
+
+class TestScopeOwnership:
+    def test_scope_token_released_after_successful_request(self, rf, logger, settings_sandbox):
+        settings_sandbox(I_DOT_AI_LOGGER=logger)
+        mw = StructuredLoggingMiddlewareOTel(lambda _r: HttpResponse(status=200))
+        mw(rf.get("/"))
+        # After request, no owner should be bound.
+        assert _request_scope_owner.get() is None
+
+    def test_scope_token_released_after_exception(self, rf, logger, settings_sandbox):
+        settings_sandbox(I_DOT_AI_LOGGER=logger)
+
+        def boom(_r):
+            msg = "no"
+            raise ValueError(msg)
+
+        mw = StructuredLoggingMiddlewareOTel(boom)
+        with pytest.raises(ValueError, match="no"):
+            mw(rf.get("/"))
+        assert _request_scope_owner.get() is None
+
+
+# ---------------------------------------------------------------------------
+# Enablement flag
+# ---------------------------------------------------------------------------
+
+
+class TestEnablementFlag:
+    def test_disabled_flag_raises_middleware_not_used(self, logger, settings_sandbox):
+        settings_sandbox(
+            I_DOT_AI_LOGGER=logger,
+            I_DOT_AI_LOGGING_MIDDLEWARE_ENABLED=False,
+        )
+        with pytest.raises(MiddlewareNotUsed):
+            StructuredLoggingMiddlewareOTel(lambda _r: HttpResponse(status=200))
+
+
+# ---------------------------------------------------------------------------
+# Http404 carve-out (Art. 46)
+# ---------------------------------------------------------------------------
+
+
+class TestHttp404CarveOut:
+    """Constitution Art. 46: ``Http404`` MUST be logged at INFO or WARNING,
+    never ERROR. Treated as ordinary traffic (``request_completed``), not a
+    server-side failure (``request_failed``).
+    """
+
+    def test_http404_logged_at_warning_not_error(self, rf, logger, settings_sandbox):
+        settings_sandbox(I_DOT_AI_LOGGER=logger)
+
+        def not_found(_request):
+            msg = "nope"
+            raise Http404(msg)
+
+        mw = StructuredLoggingMiddlewareOTel(not_found)
+        with pytest.raises(Http404):
+            mw(rf.get("/missing"))
+
+        # Emitted as request_completed, NOT request_failed.
+        completed = logger.events_for("request_completed")
+        failed = logger.events_for("request_failed")
+        assert len(completed) == 1
+        assert len(failed) == 0
+        # WARNING, not ERROR. No traceback.
+        assert completed[0]["log_level"] == "warning"
+        assert completed[0]["exception_captured"] is False
+        # Synthesised 404, not 500.
+        assert completed[0]["http.response.status_code"] == 404
+        assert completed[0]["exception.type"] == "Http404"
+        assert completed[0]["error.type"] == "404"
+
+    def test_http404_reraised_after_logging(self, rf, logger, settings_sandbox):
+        """Art. 43: exception MUST be re-raised so Django's error path
+        (404 handler, debug toolbar) still sees it.
+        """
+        settings_sandbox(I_DOT_AI_LOGGER=logger)
+
+        def not_found(_request):
+            raise Http404
+
+        mw = StructuredLoggingMiddlewareOTel(not_found)
+        with pytest.raises(Http404):
+            mw(rf.get("/missing"))
+
+
+# ---------------------------------------------------------------------------
+# `error.type` semconv field (Art. 50)
+# ---------------------------------------------------------------------------
+
+
+class TestErrorType:
+    """OTel HTTP semconv note 4: ``error.type`` carries the status code
+    string on 4xx/5xx responses and the fully-qualified exception class
+    name on the exception path. Must be absent on 2xx/3xx.
+    """
+
+    def test_error_type_absent_on_2xx(self, rf, logger, settings_sandbox):
+        settings_sandbox(I_DOT_AI_LOGGER=logger)
+        mw = StructuredLoggingMiddlewareOTel(lambda _r: HttpResponse(status=200))
+        mw(rf.get("/"))
+        completed = logger.events_for("request_completed")[0]
+        assert "error.type" not in completed
+
+    def test_error_type_absent_on_3xx(self, rf, logger, settings_sandbox):
+        settings_sandbox(I_DOT_AI_LOGGER=logger)
+        mw = StructuredLoggingMiddlewareOTel(lambda _r: HttpResponse(status=301))
+        mw(rf.get("/"))
+        completed = logger.events_for("request_completed")[0]
+        assert "error.type" not in completed
+
+    def test_error_type_is_status_string_on_4xx(self, rf, logger, settings_sandbox):
+        settings_sandbox(I_DOT_AI_LOGGER=logger)
+        mw = StructuredLoggingMiddlewareOTel(lambda _r: HttpResponse(status=403))
+        mw(rf.get("/"))
+        completed = logger.events_for("request_completed")[0]
+        assert completed["error.type"] == "403"
+
+    def test_error_type_is_status_string_on_5xx(self, rf, logger, settings_sandbox):
+        settings_sandbox(I_DOT_AI_LOGGER=logger)
+        mw = StructuredLoggingMiddlewareOTel(lambda _r: HttpResponse(status=502))
+        mw(rf.get("/"))
+        completed = logger.events_for("request_completed")[0]
+        assert completed["error.type"] == "502"
+
+    def test_error_type_is_fqn_on_unhandled_exception(self, rf, logger, settings_sandbox):
+        settings_sandbox(I_DOT_AI_LOGGER=logger)
+
+        def boom(_r):
+            msg = "broken"
+            raise RuntimeError(msg)
+
+        mw = StructuredLoggingMiddlewareOTel(boom)
+        with pytest.raises(RuntimeError, match="broken"):
+            mw(rf.get("/"))
+
+        failed = logger.events_for("request_failed")[0]
+        assert failed["error.type"] == "builtins.RuntimeError"
+        assert failed["exception.type"] == "RuntimeError"
+
+
+# ---------------------------------------------------------------------------
+# Finally-based emission idempotency (Art. 40, 47)
+# ---------------------------------------------------------------------------
+
+
+class TestEmissionIdempotency:
+    """Exactly one ``request_started`` + exactly one of
+    (``request_completed`` | ``request_failed``) per non-excluded request,
+    regardless of control-flow path (success, Http404, unhandled exception).
+    """
+
+    def test_success_emits_exactly_one_started_and_one_completed(self, rf, logger, settings_sandbox):
+        settings_sandbox(I_DOT_AI_LOGGER=logger)
+        mw = StructuredLoggingMiddlewareOTel(lambda _r: HttpResponse(status=200))
+        mw(rf.get("/"))
+
+        assert len(logger.events_for("request_started")) == 1
+        assert len(logger.events_for("request_completed")) == 1
+        assert len(logger.events_for("request_failed")) == 0
+
+    def test_http404_emits_exactly_one_started_and_one_completed(self, rf, logger, settings_sandbox):
+        settings_sandbox(I_DOT_AI_LOGGER=logger)
+
+        def not_found(_r):
+            raise Http404
+
+        mw = StructuredLoggingMiddlewareOTel(not_found)
+        with pytest.raises(Http404):
+            mw(rf.get("/"))
+
+        assert len(logger.events_for("request_started")) == 1
+        assert len(logger.events_for("request_completed")) == 1
+        assert len(logger.events_for("request_failed")) == 0
+
+    def test_exception_emits_exactly_one_started_and_one_failed(self, rf, logger, settings_sandbox):
+        settings_sandbox(I_DOT_AI_LOGGER=logger)
+
+        def boom(_r):
+            raise RuntimeError
+
+        mw = StructuredLoggingMiddlewareOTel(boom)
+        with pytest.raises(RuntimeError):
+            mw(rf.get("/"))
+
+        assert len(logger.events_for("request_started")) == 1
+        assert len(logger.events_for("request_completed")) == 0
+        assert len(logger.events_for("request_failed")) == 1
+
+
+# ---------------------------------------------------------------------------
+# Schema version (Art. 51)
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaVersion:
+    """``logging_schema_version`` MUST be bound to every event so downstream
+    consumers can detect breaking changes without grepping source.
+    """
+
+    def test_schema_version_on_startup_event(self, logger, settings_sandbox):
+        settings_sandbox(I_DOT_AI_LOGGER=logger)
+        StructuredLoggingMiddlewareOTel(lambda _r: HttpResponse(status=200))
+        startup = logger.events_for("structured_logging_middleware_otel_active")
+        assert len(startup) == 1
+        assert startup[0]["logging_schema_version"] == "1.0"
+
+    def test_schema_version_on_request_events(self, rf, logger, settings_sandbox):
+        settings_sandbox(I_DOT_AI_LOGGER=logger)
+        mw = StructuredLoggingMiddlewareOTel(lambda _r: HttpResponse(status=200))
+        mw(rf.get("/"))
+
+        for event_name in ("request_started", "request_completed"):
+            events = logger.events_for(event_name)
+            assert len(events) == 1
+            assert events[0]["logging_schema_version"] == "1.0"
+
+    def test_schema_version_on_request_failed(self, rf, logger, settings_sandbox):
+        settings_sandbox(I_DOT_AI_LOGGER=logger)
+
+        def boom(_r):
+            raise RuntimeError
+
+        mw = StructuredLoggingMiddlewareOTel(boom)
+        with pytest.raises(RuntimeError):
+            mw(rf.get("/"))
+
+        failed = logger.events_for("request_failed")[0]
+        assert failed["logging_schema_version"] == "1.0"
+
+
+# ---------------------------------------------------------------------------
+# Settings validation (Art. 15)
+# ---------------------------------------------------------------------------
+
+
+class TestSettingsValidation:
+    """Malformed settings MUST produce ``ImproperlyConfigured`` with a
+    specific message, never a bare ``TypeError`` / ``AttributeError`` /
+    ``re.error``.
+    """
+
+    def test_non_iterable_excluded_prefixes_raises_improperly_configured(self, logger, settings_sandbox):
+        settings_sandbox(
+            I_DOT_AI_LOGGER=logger,
+            I_DOT_AI_LOGGING_EXCLUDED_PREFIXES=12345,  # not iterable
+        )
+        with pytest.raises(ImproperlyConfigured, match="iterable"):
+            StructuredLoggingMiddlewareOTel(lambda _r: HttpResponse(status=200))
+
+    def test_invalid_regex_in_excluded_regexes_raises_improperly_configured(self, logger, settings_sandbox):
+        settings_sandbox(
+            I_DOT_AI_LOGGER=logger,
+            I_DOT_AI_LOGGING_EXCLUDED_REGEXES=("[unbalanced",),
+        )
+        with pytest.raises(ImproperlyConfigured, match="invalid regex"):
+            StructuredLoggingMiddlewareOTel(lambda _r: HttpResponse(status=200))
+
+    def test_non_iterable_header_allowlist_raises_improperly_configured(self, logger, settings_sandbox):
+        settings_sandbox(
+            I_DOT_AI_LOGGER=logger,
+            I_DOT_AI_LOGGING_HEADER_ALLOWLIST=42,  # not iterable
+        )
+        with pytest.raises(ImproperlyConfigured, match="iterable"):
+            StructuredLoggingMiddlewareOTel(lambda _r: HttpResponse(status=200))
+
+    def test_non_string_allowlist_entries_are_silently_skipped(self, rf, logger, settings_sandbox):
+        """Copy-paste bugs (``None`` / ``int`` in the allowlist) must not
+        brick middleware startup. Drop silently and carry on.
+        """
+        settings_sandbox(
+            I_DOT_AI_LOGGER=logger,
+            I_DOT_AI_LOGGING_HEADER_ALLOWLIST=("X-OK", None, 42, "X-Also-OK"),
+        )
+        # Must not raise.
+        mw = StructuredLoggingMiddlewareOTel(lambda _r: HttpResponse(status=200))
+        mw(rf.get("/", HTTP_X_OK="yes", HTTP_X_ALSO_OK="also-yes"))
+        completed = logger.events_for("request_completed")[0]
+        assert completed["http.request.header.x_ok"] == "yes"
+        assert completed["http.request.header.x_also_ok"] == "also-yes"
+
+
+# ---------------------------------------------------------------------------
+# Forbidden header rejection warning (Art. 53)
+# ---------------------------------------------------------------------------
+
+
+class TestForbiddenHeaderRejectionWarning:
+    def test_rejection_warning_emitted_at_startup(self, logger, settings_sandbox):
+        settings_sandbox(
+            I_DOT_AI_LOGGER=logger,
+            I_DOT_AI_LOGGING_HEADER_ALLOWLIST=("Authorization", "X-OK", "Cookie"),
+        )
+        StructuredLoggingMiddlewareOTel(lambda _r: HttpResponse(status=200))
+        rejected = logger.events_for("structured_logging_middleware_otel_forbidden_headers_rejected")
+        assert len(rejected) == 1
+        assert "Authorization" in rejected[0]["rejected"]
+        assert "Cookie" in rejected[0]["rejected"]
+        assert "X-OK" not in rejected[0]["rejected"]
+
+    def test_no_warning_when_allowlist_has_no_forbidden_entries(self, logger, settings_sandbox):
+        settings_sandbox(
+            I_DOT_AI_LOGGER=logger,
+            I_DOT_AI_LOGGING_HEADER_ALLOWLIST=("X-Tenant-ID", "X-Request-Origin"),
+        )
+        StructuredLoggingMiddlewareOTel(lambda _r: HttpResponse(status=200))
+        rejected = logger.events_for("structured_logging_middleware_otel_forbidden_headers_rejected")
+        assert len(rejected) == 0
+
+    def test_case_insensitive_rejection(self, logger, settings_sandbox):
+        settings_sandbox(
+            I_DOT_AI_LOGGER=logger,
+            I_DOT_AI_LOGGING_HEADER_ALLOWLIST=("AUTHORIZATION", "CoOkIe"),
+        )
+        StructuredLoggingMiddlewareOTel(lambda _r: HttpResponse(status=200))
+        rejected = logger.events_for("structured_logging_middleware_otel_forbidden_headers_rejected")
+        assert len(rejected) == 1
+        assert set(rejected[0]["rejected"]) == {"AUTHORIZATION", "CoOkIe"}
+
+
+# ---------------------------------------------------------------------------
+# Trace-context precedence via OTel propagator (Art. 60)
+# ---------------------------------------------------------------------------
+
+
+class TestTraceContextPrecedence:
+    """Art. 60: the ``trace_id`` precedence ladder MUST have a dedicated
+    test. With the OTel middleware, precedence is delegated to the
+    composite propagator (W3C + X-Ray), where W3C wins when both are
+    present. We verify via the span attached to the recorded server span,
+    which is the source of truth for ``trace_id`` in this middleware.
+    """
+
+    def test_w3c_traceparent_wins_over_amzn_header(self, logger, settings_sandbox):
+        from django.http import HttpResponse as _HttpResponse  # noqa: PLC0415
+        from django.test import Client  # noqa: PLC0415
+        from django.urls import clear_url_caches, path  # noqa: PLC0415
+
+        def _ok(_request):
+            return _HttpResponse(status=200)
+
+        otel_mw = [m for m in django_settings.MIDDLEWARE if "opentelemetry" in m.lower()]
+        settings_sandbox(
+            I_DOT_AI_LOGGER=logger,
+            ROOT_URLCONF=__name__,
+            MIDDLEWARE=[
+                *otel_mw,
+                "i_dot_ai_utilities.logging.middleware.django_otel.StructuredLoggingMiddlewareOTel",
+            ],
+        )
+        global urlpatterns  # noqa: PLW0603
+        prev = urlpatterns
+        urlpatterns = [path("trace-test", _ok)]
+        clear_url_caches()
+        w3c_trace_id = "0af7651916cd43dd8448eb211c80319c"
+        w3c_span_id = "b7ad6b7169203331"
+        try:
+            client = Client()
+            response = client.get(
+                "/trace-test",
+                HTTP_TRACEPARENT=f"00-{w3c_trace_id}-{w3c_span_id}-01",
+                # A fully-formed X-Ray header that, if it won, would
+                # override the trace id with a different value. The
+                # composite propagator is ordered so W3C extracts last
+                # and therefore wins.
+                HTTP_X_AMZN_TRACE_ID=("Root=1-6758db72-1234567890abcdef12345678;Parent=53995c3f42cd8ad8;Sampled=1"),
+            )
+        finally:
+            urlpatterns = prev
+            clear_url_caches()
+
+        assert response.status_code == 200
+        spans = _SHARED_EXPORTER.get_finished_spans()
+        assert spans, "DjangoInstrumentor did not emit a span"
+        # The server span's trace id must equal the W3C-provided trace id
+        # (32 hex chars, lowercase).
+        server_span = spans[-1]
+        actual_hex = format(server_span.get_span_context().trace_id, "032x")
+        assert actual_hex == w3c_trace_id
+
+    def test_amzn_header_used_when_no_traceparent(self, logger, settings_sandbox):
+        from django.http import HttpResponse as _HttpResponse  # noqa: PLC0415
+        from django.test import Client  # noqa: PLC0415
+        from django.urls import clear_url_caches, path  # noqa: PLC0415
+
+        def _ok(_request):
+            return _HttpResponse(status=200)
+
+        otel_mw = [m for m in django_settings.MIDDLEWARE if "opentelemetry" in m.lower()]
+        settings_sandbox(
+            I_DOT_AI_LOGGER=logger,
+            ROOT_URLCONF=__name__,
+            MIDDLEWARE=[
+                *otel_mw,
+                "i_dot_ai_utilities.logging.middleware.django_otel.StructuredLoggingMiddlewareOTel",
+            ],
+        )
+        global urlpatterns  # noqa: PLW0603
+        prev = urlpatterns
+        urlpatterns = [path("xray-test", _ok)]
+        clear_url_caches()
+        # Well-formed X-Ray Root: 1-<8 hex epoch>-<24 hex random>.
+        # When concatenated (epoch || random) you get a valid 32-hex id.
+        # The AWS propagator requires Parent= and Sampled= fields too;
+        # Root alone is not sufficient for the propagator to accept the
+        # span context as valid.
+        amzn_epoch = "6758db72"
+        amzn_random = "1234567890abcdef12345678"
+        amzn_parent = "53995c3f42cd8ad8"
+        try:
+            client = Client()
+            response = client.get(
+                "/xray-test",
+                HTTP_X_AMZN_TRACE_ID=(f"Root=1-{amzn_epoch}-{amzn_random};Parent={amzn_parent};Sampled=1"),
+            )
+        finally:
+            urlpatterns = prev
+            clear_url_caches()
+
+        assert response.status_code == 200
+        spans = _SHARED_EXPORTER.get_finished_spans()
+        assert spans, "DjangoInstrumentor did not emit a span"
+        server_span = spans[-1]
+        actual_hex = format(server_span.get_span_context().trace_id, "032x")
+        # X-Ray trace id is the 8+24 hex after the version prefix.
+        assert actual_hex == f"{amzn_epoch}{amzn_random}"
+
+
+# ---------------------------------------------------------------------------
+# Process-exception hook contract (Art. 45)
+# ---------------------------------------------------------------------------
+
+
+class TestProcessExceptionSafety:
+    def test_process_exception_never_raises_and_writes_nothing(self, rf, logger, settings_sandbox):
+        settings_sandbox(I_DOT_AI_LOGGER=logger)
+        mw = StructuredLoggingMiddlewareOTel(lambda _r: HttpResponse(status=200))
+        # Clear context and verify no writes happen via the hook.
+        logger.context = {}
+        events_before = len(logger.events)
+        result = mw.process_exception(rf.get("/"), RuntimeError("x"))
+        assert result is None
+        assert len(logger.events) == events_before
+        assert logger.context == {}
+
+
+# ---------------------------------------------------------------------------
+# Middleware-surface contract (Art. 1, 2)
+# ---------------------------------------------------------------------------
+
+
+class TestMiddlewareSurface:
+    def test_sync_flags_are_set(self):
+        assert StructuredLoggingMiddlewareOTel.sync_capable is True
+        assert StructuredLoggingMiddlewareOTel.async_capable is False
+
+    def test_call_returns_response_unchanged(self, rf, logger, settings_sandbox):
+        settings_sandbox(I_DOT_AI_LOGGER=logger)
+        sentinel = HttpResponse(status=204)
+        mw = StructuredLoggingMiddlewareOTel(lambda _r: sentinel)
+        assert mw(rf.get("/")) is sentinel
+
+
+# ---------------------------------------------------------------------------
+# Missing TracerProvider warning (configuration foot-gun protection)
+# ---------------------------------------------------------------------------
+
+
+class TestTracerProviderMissingWarning:
+    """If a consumer wires ``StructuredLoggingMiddlewareOTel`` into
+    ``settings.MIDDLEWARE`` but forgets to call
+    ``configure_otel_for_django`` at process startup, the logs degrade
+    silently: no ``trace_id`` / ``span_id`` on events, no spans exported.
+    The middleware detects this state at init and emits one loud WARNING
+    so operators know to fix their boot sequence."""
+
+    def _override_provider(self, replacement: Any) -> Any:
+        """Swap in an alternative tracer provider bypassing OTel's
+        'no-override' guard. Returns the previous internal state so the
+        test can restore it afterwards.
+        """
+        from opentelemetry import trace as _trace  # noqa: PLC0415
+
+        prev = (
+            _trace._TRACER_PROVIDER,  # noqa: SLF001
+            _trace._TRACER_PROVIDER_SET_ONCE._done,  # noqa: SLF001
+        )
+        _trace._TRACER_PROVIDER = replacement  # noqa: SLF001
+        # Force the once-guard back to "not set" so subsequent code paths
+        # see the replacement cleanly.
+        _trace._TRACER_PROVIDER_SET_ONCE._done = False  # noqa: SLF001
+        return prev
+
+    def _restore_provider(self, prev: Any) -> None:
+        from opentelemetry import trace as _trace  # noqa: PLC0415
+
+        _trace._TRACER_PROVIDER = prev[0]  # noqa: SLF001
+        _trace._TRACER_PROVIDER_SET_ONCE._done = prev[1]  # noqa: SLF001
+
+    def test_warning_emitted_when_no_sdk_provider(self, logger, settings_sandbox):
+        """With the API's default ``ProxyTracerProvider`` (or any non-SDK
+        provider) installed, init must emit the missing-provider WARNING.
+        """
+        from opentelemetry.trace import ProxyTracerProvider  # noqa: PLC0415
+
+        settings_sandbox(I_DOT_AI_LOGGER=logger)
+        prev = self._override_provider(ProxyTracerProvider())
+        try:
+            StructuredLoggingMiddlewareOTel(lambda _r: HttpResponse(status=200))
+        finally:
+            self._restore_provider(prev)
+
+        missing = logger.events_for("structured_logging_middleware_otel_tracer_provider_missing")
+        assert len(missing) == 1
+        event = missing[0]
+        assert event["log_level"] == "warning"
+        assert event["actual_provider"] == "ProxyTracerProvider"
+        assert "configure_otel_for_django" in event["remediation"]
+
+    def test_no_warning_when_sdk_provider_installed(self, logger, settings_sandbox):
+        """The module-level ``configure_otel_for_django`` call in this
+        test file already installed a real SDK provider, so a fresh
+        middleware construction must NOT emit the warning.
+        """
+        settings_sandbox(I_DOT_AI_LOGGER=logger)
+        StructuredLoggingMiddlewareOTel(lambda _r: HttpResponse(status=200))
+        missing = logger.events_for("structured_logging_middleware_otel_tracer_provider_missing")
+        assert len(missing) == 0
+
+    def test_warning_emission_failure_does_not_crash_init(self, settings_sandbox, capsys):
+        """A broken logger on the warning path must fall back to stderr
+        rather than breaking worker boot.
+        """
+        from opentelemetry.trace import ProxyTracerProvider  # noqa: PLC0415
+
+        class BrokenWarnLogger:
+            """Logger whose ``warning`` raises, everything else is fine."""
+
+            def info(self, *_a: Any, **_k: Any) -> None:
+                pass
+
+            def warning(self, *_a: Any, **_k: Any) -> None:
+                msg = "logger warning is broken"
+                raise RuntimeError(msg)
+
+            def error(self, *_a: Any, **_k: Any) -> None:
+                pass
+
+            def exception(self, *_a: Any, **_k: Any) -> None:
+                pass
+
+            def refresh_context(self, *_a: Any, **_k: Any) -> None:
+                pass
+
+            def set_context_field(self, *_a: Any, **_k: Any) -> None:
+                pass
+
+        settings_sandbox(I_DOT_AI_LOGGER=BrokenWarnLogger())
+        prev = self._override_provider(ProxyTracerProvider())
+        try:
+            # Must not raise.
+            StructuredLoggingMiddlewareOTel(lambda _r: HttpResponse(status=200))
+        finally:
+            self._restore_provider(prev)
+
+        captured = capsys.readouterr()
+        assert "tracer-provider-missing warning failed" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# Startup-emission stderr fallbacks
+# ---------------------------------------------------------------------------
+
+
+class TestStartupStderrFallback:
+    """Defence-in-depth for the three startup emission paths
+    (``_emit_startup_log``, ``_emit_forbidden_headers_warning``,
+    ``_warn_if_tracer_provider_missing``). An observability library MUST
+    NOT crash the worker when its own logger is broken; the fallback is
+    a ``print`` to stderr so operators can still see something went
+    wrong without Django failing to serve.
+
+    The tracer-provider-missing stderr path is already covered in
+    ``TestTracerProviderMissingWarning``; these tests cover the other
+    two, and together the three stderr guards make the "worker boot
+    with a half-broken logger" path tractable.
+    """
+
+    def test_startup_info_log_failure_falls_back_to_stderr(self, settings_sandbox, capsys):
+        class BrokenInfoLogger:
+            """Logger whose ``info`` raises, exercises the first stderr
+            fallback path in ``_emit_startup_log``."""
+
+            def info(self, *_a: Any, **_k: Any) -> None:
+                msg = "info is broken"
+                raise RuntimeError(msg)
+
+            def warning(self, *_a: Any, **_k: Any) -> None:
+                pass
+
+            def error(self, *_a: Any, **_k: Any) -> None:
+                pass
+
+            def exception(self, *_a: Any, **_k: Any) -> None:
+                pass
+
+            def refresh_context(self, *_a: Any, **_k: Any) -> None:
+                pass
+
+            def set_context_field(self, *_a: Any, **_k: Any) -> None:
+                pass
+
+        settings_sandbox(I_DOT_AI_LOGGER=BrokenInfoLogger())
+        # Must not raise despite ``info`` failing during the startup emit.
+        StructuredLoggingMiddlewareOTel(lambda _r: HttpResponse(status=200))
+
+        captured = capsys.readouterr()
+        assert "startup log emission failed" in captured.err
+        # Specifically names the underlying exception class so
+        # operators can grep for it.
+        assert "RuntimeError" in captured.err
+
+    def test_forbidden_headers_warning_failure_falls_back_to_stderr(self, settings_sandbox, capsys):
+        """When a forbidden header is supplied AND the logger's
+        ``warning`` call raises, the middleware still constructs
+        successfully with a stderr fallback naming the failure.
+        """
+
+        class BrokenWarningLogger:
+            """Logger whose ``warning`` raises. ``info`` is fine so the
+            startup log path does NOT fall back to stderr, only the
+            forbidden-headers warning does.
+            """
+
+            def info(self, *_a: Any, **_k: Any) -> None:
+                pass
+
+            def warning(self, *_a: Any, **_k: Any) -> None:
+                msg = "warning is broken"
+                raise RuntimeError(msg)
+
+            def error(self, *_a: Any, **_k: Any) -> None:
+                pass
+
+            def exception(self, *_a: Any, **_k: Any) -> None:
+                pass
+
+            def refresh_context(self, *_a: Any, **_k: Any) -> None:
+                pass
+
+            def set_context_field(self, *_a: Any, **_k: Any) -> None:
+                pass
+
+        settings_sandbox(
+            I_DOT_AI_LOGGER=BrokenWarningLogger(),
+            # ``Authorization`` is on ``FORBIDDEN_HEADER_NAMES`` so this
+            # will trigger the rejection path at startup.
+            I_DOT_AI_LOGGING_HEADER_ALLOWLIST=("Authorization", "X-Safe"),
+        )
+        # Must not raise.
+        StructuredLoggingMiddlewareOTel(lambda _r: HttpResponse(status=200))
+
+        captured = capsys.readouterr()
+        assert "forbidden-header warning failed" in captured.err
+        assert "RuntimeError" in captured.err

--- a/src/i_dot_ai_utilities/logging/__tests__/middleware/test_django_otel.py
+++ b/src/i_dot_ai_utilities/logging/__tests__/middleware/test_django_otel.py
@@ -109,7 +109,7 @@ def _clear_exporter():
 
 @pytest.fixture(autouse=True)
 def _clear_structlog_contextvars():
-    """Art. 57: ensure no structlog context bleeds between tests."""
+    """ensure no structlog context bleeds between tests."""
     structlog.contextvars.clear_contextvars()
     yield
     structlog.contextvars.clear_contextvars()
@@ -463,7 +463,7 @@ class TestHeaderAllowlist:
 
 
 class TestRequestId:
-    """Constitution Art. 30 + 32: ``request_id`` is ALWAYS a fresh per-hop
+    """``request_id`` is ALWAYS a fresh per-hop
     UUID4, distinct from any inbound correlation value. Any valid inbound
     ``X-Request-ID`` is preserved verbatim as ``upstream_request_id``.
     Charset-invalid or absent inbound values produce no
@@ -596,12 +596,12 @@ class TestEnablementFlag:
 
 
 # ---------------------------------------------------------------------------
-# Http404 carve-out (Art. 46)
+# Http404 carve-out
 # ---------------------------------------------------------------------------
 
 
 class TestHttp404CarveOut:
-    """Constitution Art. 46: ``Http404`` MUST be logged at INFO or WARNING,
+    """``Http404`` MUST be logged at INFO or WARNING,
     never ERROR. Treated as ordinary traffic (``request_completed``), not a
     server-side failure (``request_failed``).
     """
@@ -631,7 +631,7 @@ class TestHttp404CarveOut:
         assert completed[0]["error.type"] == "404"
 
     def test_http404_reraised_after_logging(self, rf, logger, settings_sandbox):
-        """Art. 43: exception MUST be re-raised so Django's error path
+        """exception MUST be re-raised so Django's error path
         (404 handler, debug toolbar) still sees it.
         """
         settings_sandbox(I_DOT_AI_LOGGER=logger)
@@ -645,7 +645,7 @@ class TestHttp404CarveOut:
 
 
 # ---------------------------------------------------------------------------
-# `error.type` semconv field (Art. 50)
+# `error.type` semconv field
 # ---------------------------------------------------------------------------
 
 
@@ -700,7 +700,7 @@ class TestErrorType:
 
 
 # ---------------------------------------------------------------------------
-# Finally-based emission idempotency (Art. 40, 47)
+# Finally-based emission idempotency
 # ---------------------------------------------------------------------------
 
 
@@ -749,7 +749,7 @@ class TestEmissionIdempotency:
 
 
 # ---------------------------------------------------------------------------
-# Schema version (Art. 51)
+# Schema version
 # ---------------------------------------------------------------------------
 
 
@@ -790,7 +790,7 @@ class TestSchemaVersion:
 
 
 # ---------------------------------------------------------------------------
-# Settings validation (Art. 15)
+# Settings validation
 # ---------------------------------------------------------------------------
 
 
@@ -841,7 +841,7 @@ class TestSettingsValidation:
 
 
 # ---------------------------------------------------------------------------
-# Forbidden header rejection warning (Art. 53)
+# Forbidden header rejection warning
 # ---------------------------------------------------------------------------
 
 
@@ -879,12 +879,12 @@ class TestForbiddenHeaderRejectionWarning:
 
 
 # ---------------------------------------------------------------------------
-# Trace-context precedence via OTel propagator (Art. 60)
+# Trace-context precedence via OTel propagator
 # ---------------------------------------------------------------------------
 
 
 class TestTraceContextPrecedence:
-    """Art. 60: the ``trace_id`` precedence ladder MUST have a dedicated
+    """the ``trace_id`` precedence ladder MUST have a dedicated
     test. With the OTel middleware, precedence is delegated to the
     composite propagator (W3C + X-Ray), where W3C wins when both are
     present. We verify via the span attached to the recorded server span,
@@ -987,7 +987,7 @@ class TestTraceContextPrecedence:
 
 
 # ---------------------------------------------------------------------------
-# Process-exception hook contract (Art. 45)
+# Process-exception hook contract
 # ---------------------------------------------------------------------------
 
 
@@ -1005,7 +1005,7 @@ class TestProcessExceptionSafety:
 
 
 # ---------------------------------------------------------------------------
-# Middleware-surface contract (Art. 1, 2)
+# Middleware-surface contract
 # ---------------------------------------------------------------------------
 
 

--- a/src/i_dot_ai_utilities/logging/__tests__/middleware/test_django_user_id.py
+++ b/src/i_dot_ai_utilities/logging/__tests__/middleware/test_django_user_id.py
@@ -1,0 +1,437 @@
+# mypy: disable-error-code="no-untyped-def"
+"""Unit tests for ``DjangoUserIdMiddleware``.
+
+The middleware is the replacement for the deleted ``DjangoEnricher``'s
+user-extraction path. These tests specifically target the hardening
+lifted from that enricher: FI-5 (no DB query on unhydrated lazy users),
+database-error-surfacing via WARNING, and the anonymous/authenticated
+branches.
+
+``RecordingLogger`` captures ``set_context_field`` / ``warning`` calls
+so assertions can be made without configuring structlog.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+django = pytest.importorskip("django")
+
+from django.conf import settings as django_settings  # type: ignore[import-untyped]  # noqa: E402
+
+if not django_settings.configured:
+    django_settings.configure(
+        DEBUG=False,
+        ALLOWED_HOSTS=["*"],
+        DATABASES={},
+        INSTALLED_APPS=[],
+        ROOT_URLCONF=__name__,
+        MIDDLEWARE=[],
+        SECRET_KEY="test-secret-not-for-production",
+        USE_TZ=True,
+    )
+    import django as _django  # type: ignore[import-untyped]
+
+    _django.setup()
+
+from django.core.exceptions import MiddlewareNotUsed  # type: ignore[import-untyped]  # noqa: E402
+from django.http import HttpResponse  # type: ignore[import-untyped]  # noqa: E402
+from django.test import RequestFactory  # type: ignore[import-untyped]  # noqa: E402
+from django.utils.functional import SimpleLazyObject  # type: ignore[import-untyped]  # noqa: E402
+
+from i_dot_ai_utilities.logging.middleware.django_user_id import (  # noqa: E402
+    DjangoUserIdMiddleware,
+)
+
+urlpatterns: list = []
+
+
+# ---------------------------------------------------------------------------
+# Test doubles
+# ---------------------------------------------------------------------------
+
+
+class RecordingLogger:
+    """Structured-logger double matching the middleware's protocol."""
+
+    def __init__(self) -> None:
+        self.context: dict[str, Any] = {}
+        self.warnings: list[str] = []
+        self.infos: list[str] = []
+        self.errors: list[str] = []
+        self.exceptions: list[str] = []
+        self.refresh_calls: list[tuple[list[Any] | None, str]] = []
+
+    def info(self, message_template: str, **_kwargs: Any) -> None:
+        self.infos.append(message_template)
+
+    def warning(self, message_template: str, **_kwargs: Any) -> None:
+        self.warnings.append(message_template)
+
+    def error(self, message_template: str, **_kwargs: Any) -> None:
+        self.errors.append(message_template)
+
+    def exception(self, message_template: str, **_kwargs: Any) -> None:
+        self.exceptions.append(message_template)
+
+    def set_context_field(self, key: str, value: Any) -> None:
+        self.context[key] = value
+
+    def refresh_context(
+        self,
+        context_enrichers: list[Any] | None = None,
+        scope: str = "manual",
+    ) -> None:
+        self.refresh_calls.append((context_enrichers, scope))
+
+
+class _FakeUser:
+    """Minimal duck-typed user object."""
+
+    def __init__(
+        self,
+        *,
+        is_authenticated: bool = True,
+        pk: Any = 42,
+        id: Any = None,  # noqa: A002 - mirrors Django's user attr name
+    ) -> None:
+        self.is_authenticated = is_authenticated
+        self.pk = pk
+        self.id = id
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def rf() -> RequestFactory:
+    return RequestFactory()
+
+
+@pytest.fixture
+def logger() -> RecordingLogger:
+    return RecordingLogger()
+
+
+@pytest.fixture
+def settings_sandbox():
+    """Restore any attribute changes on ``django.conf.settings``."""
+    snapshot: dict[str, Any] = {}
+    marker = object()
+
+    def apply(**kwargs: Any) -> None:
+        for k, v in kwargs.items():
+            snapshot[k] = getattr(django_settings, k, marker)
+            setattr(django_settings, k, v)
+
+    yield apply
+
+    for k, v in snapshot.items():
+        if v is marker:
+            if hasattr(django_settings, k):
+                delattr(django_settings, k)
+        else:
+            setattr(django_settings, k, v)
+
+
+# ---------------------------------------------------------------------------
+# Happy paths
+# ---------------------------------------------------------------------------
+
+
+class TestAuthenticatedUser:
+    def test_binds_user_id_from_pk(self, rf, logger, settings_sandbox):
+        settings_sandbox(I_DOT_AI_LOGGER=logger)
+        request = rf.get("/")
+        request.user = _FakeUser(is_authenticated=True, pk=99)
+
+        mw = DjangoUserIdMiddleware(lambda _r: HttpResponse(status=200))
+        mw(request)
+
+        assert logger.context == {"user.id": "99"}
+
+    def test_falls_back_to_id_when_pk_is_none(self, rf, logger, settings_sandbox):
+        settings_sandbox(I_DOT_AI_LOGGER=logger)
+        request = rf.get("/")
+        request.user = _FakeUser(is_authenticated=True, pk=None, id="user-xyz")
+
+        mw = DjangoUserIdMiddleware(lambda _r: HttpResponse(status=200))
+        mw(request)
+
+        assert logger.context == {"user.id": "user-xyz"}
+
+    def test_stringifies_non_string_pk(self, rf, logger, settings_sandbox):
+        settings_sandbox(I_DOT_AI_LOGGER=logger)
+        request = rf.get("/")
+        request.user = _FakeUser(is_authenticated=True, pk=1234)
+
+        mw = DjangoUserIdMiddleware(lambda _r: HttpResponse(status=200))
+        mw(request)
+
+        assert logger.context["user.id"] == "1234"
+        assert isinstance(logger.context["user.id"], str)
+
+
+# ---------------------------------------------------------------------------
+# Branches that must NOT bind anything
+# ---------------------------------------------------------------------------
+
+
+class TestSkippedPaths:
+    def test_anonymous_user_emits_nothing(self, rf, logger, settings_sandbox):
+        settings_sandbox(I_DOT_AI_LOGGER=logger)
+        request = rf.get("/")
+        request.user = _FakeUser(is_authenticated=False, pk=1)
+
+        mw = DjangoUserIdMiddleware(lambda _r: HttpResponse(status=200))
+        mw(request)
+
+        assert logger.context == {}
+        assert logger.warnings == []
+
+    def test_is_authenticated_not_exactly_true_is_treated_as_anonymous(self, rf, logger, settings_sandbox):
+        """Truthy-but-not-True values must not bind user.id.
+
+        Defensive against duck-typed or mocked user objects whose
+        ``is_authenticated`` is a truthy sentinel rather than a real bool.
+        """
+        settings_sandbox(I_DOT_AI_LOGGER=logger)
+        request = rf.get("/")
+        request.user = _FakeUser(is_authenticated="yes", pk=1)  # type: ignore[arg-type]
+
+        mw = DjangoUserIdMiddleware(lambda _r: HttpResponse(status=200))
+        mw(request)
+
+        assert logger.context == {}
+
+    def test_missing_user_attr_emits_nothing(self, rf, logger, settings_sandbox):
+        """Auth middleware hasn't run, so absence of request.user is fine."""
+        settings_sandbox(I_DOT_AI_LOGGER=logger)
+        request = rf.get("/")
+        # Deliberately do NOT set request.user.
+
+        mw = DjangoUserIdMiddleware(lambda _r: HttpResponse(status=200))
+        mw(request)
+
+        assert logger.context == {}
+        assert logger.warnings == []
+
+    def test_authenticated_but_pk_and_id_both_none_emits_nothing(self, rf, logger, settings_sandbox):
+        settings_sandbox(I_DOT_AI_LOGGER=logger)
+        request = rf.get("/")
+        request.user = _FakeUser(is_authenticated=True, pk=None, id=None)
+
+        mw = DjangoUserIdMiddleware(lambda _r: HttpResponse(status=200))
+        mw(request)
+
+        assert logger.context == {}
+
+
+class TestUnhydratedLazyObject:
+    """FI-5: reading ``.pk`` on an unhydrated ``SimpleLazyObject`` makes the
+    auth backend run a ``User.objects.get(...)`` query. The middleware must
+    skip a lazy user without triggering that hydration.
+
+    These use the real ``django.utils.functional.SimpleLazyObject`` so the
+    ``_wrapped is empty`` sentinel and the attribute-proxying behaviour match
+    production rather than a stand-in that could drift from Django.
+    """
+
+    def test_unhydrated_lazy_object_is_skipped_without_hydrating(self, rf, logger, settings_sandbox):
+        settings_sandbox(I_DOT_AI_LOGGER=logger)
+        hydrated: list[bool] = []
+
+        def _hydrate() -> Any:
+            # Django runs this on first attribute access; it stands in for the
+            # DB query, so a non-empty list means the middleware forced it.
+            hydrated.append(True)
+            return _FakeUser(is_authenticated=True, pk=7)
+
+        request = rf.get("/")
+        request.user = SimpleLazyObject(_hydrate)
+
+        mw = DjangoUserIdMiddleware(lambda _r: HttpResponse(status=200))
+        mw(request)
+
+        assert hydrated == []
+        assert logger.context == {}
+        assert logger.warnings == []
+
+    def test_hydrated_lazy_object_falls_through_to_normal_extraction(self, rf, logger, settings_sandbox):
+        settings_sandbox(I_DOT_AI_LOGGER=logger)
+        request = rf.get("/")
+        lazy = SimpleLazyObject(lambda: _FakeUser(is_authenticated=True, pk=7))
+        # Force hydration the way a view or auth code would before our
+        # middleware reads the user, so ``_wrapped`` is no longer the sentinel.
+        assert lazy.pk == 7
+        request.user = lazy
+
+        mw = DjangoUserIdMiddleware(lambda _r: HttpResponse(status=200))
+        mw(request)
+
+        assert logger.context == {"user.id": "7"}
+
+
+# ---------------------------------------------------------------------------
+# Database error surfacing
+# ---------------------------------------------------------------------------
+
+
+class _ExplodingUserIsAuth:
+    """User object whose ``is_authenticated`` access raises OperationalError."""
+
+    class _OperationalError(Exception):
+        """Named to match Django's class name for MRO detection."""
+
+    # Intentionally rename at class-creation time so the MRO name match
+    # triggers in the middleware's ``_is_database_error`` helper.
+    _OperationalError.__name__ = "OperationalError"
+
+    @property
+    def is_authenticated(self) -> bool:
+        msg = "connection refused"
+        raise self._OperationalError(msg)
+
+
+class _ExplodingUserPk:
+    """Authenticated user whose ``pk`` access raises DatabaseError."""
+
+    class _DatabaseError(Exception):
+        pass
+
+    _DatabaseError.__name__ = "DatabaseError"
+
+    is_authenticated = True
+
+    @property
+    def pk(self) -> Any:
+        msg = "db gone"
+        raise self._DatabaseError(msg)
+
+    @property
+    def id(self) -> Any:
+        msg = "db gone"
+        raise self._DatabaseError(msg)
+
+
+class _NonDbExceptionOnIsAuth:
+    """User whose ``is_authenticated`` raises a non-DB exception."""
+
+    @property
+    def is_authenticated(self) -> bool:
+        msg = "something unrelated"
+        raise ValueError(msg)
+
+
+class TestDatabaseErrors:
+    def test_db_error_on_is_authenticated_warns_and_continues(self, rf, logger, settings_sandbox):
+        settings_sandbox(I_DOT_AI_LOGGER=logger)
+        request = rf.get("/")
+        request.user = _ExplodingUserIsAuth()
+
+        mw = DjangoUserIdMiddleware(lambda _r: HttpResponse(status=200))
+        response = mw(request)
+
+        assert response.status_code == 200
+        assert logger.context == {}
+        assert len(logger.warnings) == 1
+        assert "is_authenticated" in logger.warnings[0]
+        assert "Database error" in logger.warnings[0]
+
+    def test_db_error_on_pk_warns_and_continues(self, rf, logger, settings_sandbox):
+        settings_sandbox(I_DOT_AI_LOGGER=logger)
+        request = rf.get("/")
+        request.user = _ExplodingUserPk()
+
+        mw = DjangoUserIdMiddleware(lambda _r: HttpResponse(status=200))
+        response = mw(request)
+
+        assert response.status_code == 200
+        assert logger.context == {}
+        assert len(logger.warnings) == 1
+        assert "primary key" in logger.warnings[0]
+        assert "Database error" in logger.warnings[0]
+
+    def test_non_db_exception_on_is_authenticated_is_silenced_without_warning(self, rf, logger, settings_sandbox):
+        """Non-DB errors are observability problems, not user-visible ones.
+
+        The middleware must still not take the request down, but it also
+        must not spam WARNINGs for every unrelated exception.
+        """
+        settings_sandbox(I_DOT_AI_LOGGER=logger)
+        request = rf.get("/")
+        request.user = _NonDbExceptionOnIsAuth()
+
+        mw = DjangoUserIdMiddleware(lambda _r: HttpResponse(status=200))
+        response = mw(request)
+
+        assert response.status_code == 200
+        assert logger.context == {}
+        assert logger.warnings == []
+
+
+# ---------------------------------------------------------------------------
+# Middleware protocol / lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestProtocol:
+    def test_disabled_raises_middleware_not_used(self, settings_sandbox, logger):
+        settings_sandbox(I_DOT_AI_LOGGING_MIDDLEWARE_ENABLED=False, I_DOT_AI_LOGGER=logger)
+
+        with pytest.raises(MiddlewareNotUsed):
+            DjangoUserIdMiddleware(lambda _r: HttpResponse(status=200))
+
+    def test_process_exception_returns_none_and_leaves_context_untouched(self, rf, logger, settings_sandbox):
+        settings_sandbox(I_DOT_AI_LOGGER=logger)
+        mw = DjangoUserIdMiddleware(lambda _r: HttpResponse(status=200))
+
+        request = rf.get("/")
+        result = mw.process_exception(request, RuntimeError("boom"))
+
+        assert result is None
+        # Processing the exception must not alter log context.
+        assert logger.context == {}
+
+    def test_sync_capable_flags(self):
+        assert DjangoUserIdMiddleware.sync_capable is True
+        assert DjangoUserIdMiddleware.async_capable is False
+
+    def test_broken_logger_warning_falls_back_to_stderr_without_crashing(self, rf, settings_sandbox, capsys):
+        class BrokenLogger:
+            def set_context_field(self, *_a: Any, **_k: Any) -> None:
+                pass
+
+            def warning(self, *_a: Any, **_k: Any) -> None:
+                msg = "logger broken"
+                raise RuntimeError(msg)
+
+            # Minimum surface the resolve_logger protocol demands.
+            def info(self, *_a: Any, **_k: Any) -> None:
+                pass
+
+            def error(self, *_a: Any, **_k: Any) -> None:
+                pass
+
+            def exception(self, *_a: Any, **_k: Any) -> None:
+                pass
+
+            def refresh_context(self, *_a: Any, **_k: Any) -> None:
+                pass
+
+        settings_sandbox(I_DOT_AI_LOGGER=BrokenLogger())
+        request = rf.get("/")
+        request.user = _ExplodingUserPk()
+
+        mw = DjangoUserIdMiddleware(lambda _r: HttpResponse(status=200))
+        # Must not raise even though both the user access AND the warning
+        # path explode.
+        response = mw(request)
+        assert response.status_code == 200
+
+        captured = capsys.readouterr()
+        assert "user.id db-error warning failed" in captured.err

--- a/src/i_dot_ai_utilities/logging/__tests__/middleware/test_request_id.py
+++ b/src/i_dot_ai_utilities/logging/__tests__/middleware/test_request_id.py
@@ -1,0 +1,173 @@
+# mypy: disable-error-code="no-untyped-def"
+"""Unit tests for ``middleware._headers.validate_request_id``.
+
+This helper is the single line of defence between an attacker-controlled
+``X-Request-ID`` header and the log context. Its failure mode is
+security finding A3: accepting structural characters verbatim enables
+log-injection, log-search hijack, and cross-tenant correlation poisoning.
+
+Every rejection case below documents a specific attack class. Keep the
+charset regex (``_REQUEST_ID_CHARSET_RE``) in lockstep with this test
+file; if a reject case starts passing, the regex has been loosened and
+the security property is gone.
+
+Pure Python helper, no Django / OTel imports, no ``importorskip``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from i_dot_ai_utilities.logging._limits import MAX_REQUEST_ID
+from i_dot_ai_utilities.logging.middleware._headers import validate_request_id
+
+
+class TestAcceptedInputs:
+    def test_short_alphanumeric_passes_through(self):
+        assert validate_request_id("abc-123") == "abc-123"
+
+    def test_uuid_shape_accepted(self):
+        uuid_hex = "0123456789abcdef0123456789abcdef"
+        assert validate_request_id(uuid_hex) == uuid_hex
+
+    def test_uuid_with_dashes_accepted(self):
+        value = "0af76519-16cd-43dd-8448-eb211c80319c"
+        assert validate_request_id(value) == value
+
+    def test_cloudfront_style_base64_accepted(self):
+        # X-Amz-Cf-Id style, opaque, mixed case, includes ``=`` + ``+`` + ``/``.
+        value = "AbC123+/=_some-opaque-id"
+        assert validate_request_id(value) == value
+
+    def test_underscore_and_period_accepted(self):
+        assert validate_request_id("job.42_retry.3") == "job.42_retry.3"
+
+    def test_colon_accepted(self):
+        # Colon is RFC 3986-reserved but appears in some tracing ids.
+        assert validate_request_id("tenant:42") == "tenant:42"
+
+
+class TestWhitespaceHandling:
+    def test_leading_and_trailing_whitespace_stripped(self):
+        assert validate_request_id("  abc-123  ") == "abc-123"
+
+    def test_leading_tab_and_newline_stripped(self):
+        assert validate_request_id("\t\nabc-123\t\n") == "abc-123"
+
+
+class TestRejectedInputs:
+    @pytest.mark.parametrize(
+        "value",
+        [
+            pytest.param(None, id="none"),
+            pytest.param("", id="empty_string"),
+            pytest.param("   ", id="whitespace_only"),
+            pytest.param("\t\n\r", id="ws_chars_only"),
+        ],
+    )
+    def test_empty_like_returns_none(self, value):
+        assert validate_request_id(value) is None
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            pytest.param(12345, id="int"),
+            pytest.param(12.5, id="float"),
+            pytest.param(b"abc-123", id="bytes"),
+            pytest.param(["abc"], id="list"),
+            pytest.param({"id": "abc"}, id="dict"),
+            pytest.param(object(), id="arbitrary_object"),
+        ],
+    )
+    def test_non_string_returns_none(self, value):
+        # Line 89 of _headers.py: ``not isinstance(value, str) -> None``.
+        # Security: non-string inputs shouldn't even reach the charset
+        # check; Python's ``str()`` on arbitrary objects would smuggle
+        # attacker-chosen repr content into the charset gate.
+        assert validate_request_id(value) is None
+
+    @pytest.mark.parametrize(
+        ("value", "attack_class"),
+        [
+            pytest.param("has space", "space-lets-grafana-split-queries", id="space"),
+            pytest.param("has\ttab", "tab-injection", id="tab"),
+            pytest.param("has\nnewline", "log-line-injection", id="newline"),
+            pytest.param("has\rcr", "log-line-injection_cr", id="carriage_return"),
+            pytest.param("has\x00null", "null-byte-injection", id="null_byte"),
+            pytest.param("has\x1bescape", "ansi-escape-injection", id="escape_char"),
+            pytest.param('has"quote', "json-structure-injection", id="double_quote"),
+            pytest.param("has'quote", "sql-like-injection", id="single_quote"),
+            pytest.param("has;semicolon", "log-field-separator", id="semicolon"),
+            pytest.param("has,comma", "csv-separator", id="comma"),
+            pytest.param("has<angle>", "html-injection", id="angle_brackets"),
+            pytest.param("has|pipe", "shell-pipe", id="pipe"),
+            pytest.param("has`backtick", "shell-substitution", id="backtick"),
+            pytest.param("has$dollar", "variable-interpolation", id="dollar"),
+            pytest.param("has\\backslash", "escape-injection", id="backslash"),
+            pytest.param("has#hash", "yaml-comment", id="hash"),
+            pytest.param("has(paren", "structure", id="paren"),
+            pytest.param("has*star", "glob", id="asterisk"),
+            pytest.param("has?question", "glob", id="question"),
+            pytest.param("has{brace}", "templating", id="brace"),
+            pytest.param("has@at", "email-like", id="at_sign"),
+        ],
+    )
+    def test_rejects_disallowed_characters(self, value, attack_class):
+        """Every character outside RFC 3986 unreserved + common base64 /
+        JWT separators must be refused. ``attack_class`` documents the
+        threat model each rejection closes so future maintainers
+        understand why the regex is deliberately tight.
+        """
+        # ``attack_class`` is unused at runtime but makes grep-for-threat
+        # easier when the charset regex is next revisited.
+        _ = attack_class
+        assert validate_request_id(value) is None
+
+
+class TestTruncation:
+    def test_truncates_to_default_max_length(self):
+        result = validate_request_id("x" * 1000)
+        assert result is not None
+        assert len(result) == MAX_REQUEST_ID
+        assert result == "x" * MAX_REQUEST_ID
+
+    def test_explicit_max_length_is_honoured(self):
+        assert validate_request_id("abcdef", max_length=3) == "abc"
+
+    def test_at_limit_is_passed_through_unchanged(self):
+        value = "x" * MAX_REQUEST_ID
+        assert validate_request_id(value) == value
+
+    def test_truncation_happens_before_charset_check(self):
+        """Otherwise a payload longer than ``max_length`` containing
+        structural characters only *after* the cut-off would be accepted
+        based on its truncated tail. The helper truncates FIRST then
+        validates, so the tail is what determines acceptance. A payload
+        with banned chars in the first ``max_length`` bytes must still
+        be rejected.
+        """
+        # Disallowed character at position 0; truncation to 10 chars
+        # cannot save it.
+        assert validate_request_id(" bad payload", max_length=10) is None
+
+
+class TestInjectionPayloadsRejected:
+    """Regression tests for known-bad payloads. These are the exact
+    shapes security reviewers have flagged; keep them here so reviewers
+    can verify mitigation by name.
+    """
+
+    def test_quote_injection_payload_rejected(self):
+        assert validate_request_id('victim-id" injected="pwned') is None
+
+    def test_newline_log_splitting_payload_rejected(self):
+        assert validate_request_id("victim-id\nFAKE_LOG_LINE request_id=attacker") is None
+
+    def test_ansi_escape_payload_rejected(self):
+        assert validate_request_id("\x1b[31mRED\x1b[0m") is None
+
+    def test_loki_logql_injection_payload_rejected(self):
+        # Loki label filters use {x="y"}; a value containing {} would
+        # corrupt on-the-fly query construction if a downstream tool
+        # ever interpolated it.
+        assert validate_request_id('xyz"}|= "steal') is None

--- a/src/i_dot_ai_utilities/logging/__tests__/middleware/test_request_id.py
+++ b/src/i_dot_ai_utilities/logging/__tests__/middleware/test_request_id.py
@@ -2,8 +2,8 @@
 """Unit tests for ``middleware._headers.validate_request_id``.
 
 This helper is the single line of defence between an attacker-controlled
-``X-Request-ID`` header and the log context. Its failure mode is
-security finding A3: accepting structural characters verbatim enables
+``X-Request-ID`` header and the log context. Its failure mode:
+accepting structural characters verbatim enables
 log-injection, log-search hijack, and cross-tenant correlation poisoning.
 
 Every rejection case below documents a specific attack class. Keep the
@@ -153,7 +153,7 @@ class TestTruncation:
 
 class TestInjectionPayloadsRejected:
     """Regression tests for known-bad payloads. These are the exact
-    shapes security reviewers have flagged; keep them here so reviewers
+    shapes that enable log-injection; keep them here so reviewers
     can verify mitigation by name.
     """
 

--- a/src/i_dot_ai_utilities/logging/__tests__/test_instantiation.py
+++ b/src/i_dot_ai_utilities/logging/__tests__/test_instantiation.py
@@ -5,8 +5,16 @@ import os
 
 import pytest
 
-from i_dot_ai_utilities.logging.structured_logger import StructuredLogger
-from i_dot_ai_utilities.logging.types.enrichment_types import ExecutionEnvironmentType
+from i_dot_ai_utilities.logging.structured_logger import (
+    REQUEST_SCOPE_OWNER_MIDDLEWARE,
+    StructuredLogger,
+    _claim_request_scope,
+    _release_request_scope,
+)
+from i_dot_ai_utilities.logging.types.enrichment_types import (
+    ContextEnrichmentType,
+    ExecutionEnvironmentType,
+)
 from i_dot_ai_utilities.logging.types.log_output_format import LogOutputFormat
 
 
@@ -179,3 +187,125 @@ def test_log_name_set(capsys):
 
     assert parsed[0].get("logger_name") == __name__
     assert parsed[1].get("logger_name") == __name__
+
+
+# ---------------------------------------------------------------------------
+# Request-scope ownership (security finding: residual flaw)
+# ---------------------------------------------------------------------------
+
+
+class TestRefreshContextScopeOwnership:
+    """Manual ``refresh_context()`` calls inside an active request scope are
+    no-ops with a warning, preventing silent de-correlation of audit trails.
+    """
+
+    def _parse(self, capsys):
+        captured = capsys.readouterr()
+        return [json.loads(line) for line in captured.out.strip().splitlines()]
+
+    def test_manual_refresh_inside_scope_is_no_op_and_warns(self, capsys):
+        logger = StructuredLogger(options={"execution_environment": ExecutionEnvironmentType.LOCAL})
+        logger.set_context_field("bound_by_middleware", "value-that-must-survive")
+
+        token = _claim_request_scope(REQUEST_SCOPE_OWNER_MIDDLEWARE)
+        try:
+            # Scope-unaware caller (e.g. an old view) tries to refresh.
+            logger.refresh_context()
+            logger.info("after manual refresh attempt")
+        finally:
+            _release_request_scope(token)
+
+        parsed = self._parse(capsys)
+        # A warning is logged informing the operator of the skipped clear.
+        warning_messages = [p.get("message", "") for p in parsed]
+        assert any("refresh_context" in m and "middleware-owned" in m for m in warning_messages), (
+            f"expected warning about skipped clear, got {warning_messages}"
+        )
+
+        # The post-refresh info log STILL carries the field bound before the
+        # scope-aware refresh attempt, i.e. the clear was skipped.
+        info_line = parsed[-1]
+        assert info_line.get("bound_by_middleware") == "value-that-must-survive"
+
+    def test_manual_refresh_outside_scope_clears_as_before(self, capsys):
+        logger = StructuredLogger(options={"execution_environment": ExecutionEnvironmentType.LOCAL})
+        logger.set_context_field("temporary_field", "before-refresh")
+        logger.refresh_context()
+        logger.info("after refresh")
+
+        parsed = self._parse(capsys)
+        # No scope was claimed: the clear ran normally and the field is gone.
+        assert parsed[-1].get("temporary_field") is None
+
+    def test_job_scope_bypasses_ownership_check(self, capsys):
+        """Background workers pass ``scope='job'`` and must be able to clear
+        context even when a request scope is somehow still active (e.g. an
+        RQ worker running on the same thread as Gunicorn in dev)."""
+        logger = StructuredLogger(options={"execution_environment": ExecutionEnvironmentType.LOCAL})
+        logger.set_context_field("stale_request_field", "leftover")
+
+        token = _claim_request_scope(REQUEST_SCOPE_OWNER_MIDDLEWARE)
+        try:
+            logger.refresh_context(scope="job")
+            logger.info("after job refresh")
+        finally:
+            _release_request_scope(token)
+
+        parsed = self._parse(capsys)
+        # Job scope opts out of the ownership check, so the field is cleared.
+        assert parsed[-1].get("stale_request_field") is None
+
+    def test_enrichers_still_apply_when_clear_is_skipped(self, capsys):
+        """When the clear is skipped, enrichers passed to ``refresh_context``
+        should still be applied on top of the existing context so callers
+        that wanted to add fields aren't silently dropped.
+
+        Uses a minimal FastAPI-shaped request object; the FastAPI
+        enricher validates structural conformance to ``RequestLike`` via
+        a runtime-checkable Protocol.
+        """
+        from starlette.datastructures import URL, Headers  # noqa: PLC0415
+        from starlette.requests import Request  # noqa: PLC0415
+
+        scope = {
+            "type": "http",
+            "method": "GET",
+            "path": "/x",
+            "raw_path": b"/x",
+            "query_string": b"",
+            "headers": Headers({"host": "testserver"}).raw,
+            "scheme": "http",
+            "server": ("testserver", 80),
+            "client": ("127.0.0.1", 12345),
+            "http_version": "1.1",
+            "root_path": "",
+        }
+        request = Request(scope)
+        # Sanity: make sure the enricher's expected surface is present.
+        assert request.method == "GET"
+        assert isinstance(request.url, URL)
+
+        logger = StructuredLogger(options={"execution_environment": ExecutionEnvironmentType.LOCAL})
+        logger.set_context_field("keep_me", "from-middleware")
+
+        token = _claim_request_scope(REQUEST_SCOPE_OWNER_MIDDLEWARE)
+        try:
+            logger.refresh_context(
+                context_enrichers=[
+                    {
+                        "type": ContextEnrichmentType.FASTAPI,
+                        "object": request,
+                    }
+                ],
+            )
+            logger.info("after skipped-clear-with-enrichers")
+        finally:
+            _release_request_scope(token)
+
+        parsed = self._parse(capsys)
+        line = parsed[-1]
+        # Pre-existing field survived the skipped clear.
+        assert line.get("keep_me") == "from-middleware"
+        # Enricher-sourced field was still applied. FastApiEnricher
+        # nests its output under ``request`` per the existing schema.
+        assert line.get("request", {}).get("method") == "GET"

--- a/src/i_dot_ai_utilities/logging/__tests__/test_instantiation.py
+++ b/src/i_dot_ai_utilities/logging/__tests__/test_instantiation.py
@@ -190,7 +190,7 @@ def test_log_name_set(capsys):
 
 
 # ---------------------------------------------------------------------------
-# Request-scope ownership (security finding: residual flaw)
+# Request-scope ownership
 # ---------------------------------------------------------------------------
 
 

--- a/src/i_dot_ai_utilities/logging/__tests__/test_middleware_exclusions.py
+++ b/src/i_dot_ai_utilities/logging/__tests__/test_middleware_exclusions.py
@@ -1,0 +1,102 @@
+# mypy: disable-error-code="no-untyped-def"
+"""Unit tests for the ``ExclusionMatcher`` class."""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from i_dot_ai_utilities.logging.middleware._exclusions import (
+    DEFAULT_EXCLUDED_PREFIXES,
+    ExclusionMatcher,
+)
+
+
+class TestDefaultExcludedPrefixes:
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/health/",
+            "/health/detail",
+            "/healthz",
+            "/healthz/",
+            "/api/health/",
+            "/api/health/live",
+            "/api/health/ready",
+        ],
+    )
+    def test_default_prefixes_match(self, path):
+        matcher = ExclusionMatcher(DEFAULT_EXCLUDED_PREFIXES)
+        assert matcher.matches(path) is True
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/api/users",
+            "/",
+            "/he",  # prefix of /health but not a real match
+            "/healthcare",  # NOT a health-check path
+            "/api/users/healthz",
+        ],
+    )
+    def test_non_matching_paths(self, path):
+        matcher = ExclusionMatcher(DEFAULT_EXCLUDED_PREFIXES)
+        assert matcher.matches(path) is False
+
+
+class TestEmptyMatcher:
+    def test_matches_nothing(self):
+        matcher = ExclusionMatcher()
+        assert matcher.matches("/") is False
+        assert matcher.matches("/healthz") is False
+        assert matcher.matches("") is False
+
+
+class TestRegexMatching:
+    def test_string_regex_is_compiled(self):
+        matcher = ExclusionMatcher(regexes=[r"^/probe/\d+$"])
+        assert matcher.matches("/probe/42") is True
+        assert matcher.matches("/probe/abc") is False
+
+    def test_precompiled_pattern_is_reused_by_identity(self):
+        pattern = re.compile(r"^/ping$")
+        matcher = ExclusionMatcher(regexes=[pattern])
+        # We rely on __slots__ + tuple storage; no direct attr access in public
+        # API. Verify behaviour rather than implementation: a precompiled
+        # pattern's .search is called, not re-compiled.
+        assert matcher.matches("/ping") is True
+        # Confirm same pattern object stored by matching on a sentinel attribute.
+        # (We can't access _regexes externally without a slot violation; the
+        # behavioural assertion above is sufficient.)
+
+    def test_empty_path_never_matches(self):
+        matcher = ExclusionMatcher(
+            prefixes=["/"],
+            regexes=[r".*"],
+        )
+        # Even with a permissive prefix/regex, an empty path returns False;
+        # guards against logging spurious empty-path cases.
+        assert matcher.matches("") is False
+
+    def test_combines_prefix_and_regex(self):
+        matcher = ExclusionMatcher(
+            prefixes=["/health"],
+            regexes=[r"^/metrics$"],
+        )
+        assert matcher.matches("/health/foo") is True
+        assert matcher.matches("/metrics") is True
+        assert matcher.matches("/nope") is False
+
+    def test_regex_search_not_fullmatch(self):
+        # The matcher uses .search so anchoring is up to the user.
+        matcher = ExclusionMatcher(regexes=[r"probe"])
+        assert matcher.matches("/api/probe/status") is True
+
+
+class TestRepr:
+    def test_includes_prefixes_and_regexes(self):
+        matcher = ExclusionMatcher(prefixes=["/x"], regexes=[r"^/y$"])
+        rendered = repr(matcher)
+        assert "/x" in rendered
+        assert "^/y$" in rendered

--- a/src/i_dot_ai_utilities/logging/__tests__/test_middleware_levels.py
+++ b/src/i_dot_ai_utilities/logging/__tests__/test_middleware_levels.py
@@ -1,0 +1,75 @@
+# mypy: disable-error-code="no-untyped-def"
+"""Unit tests for ``_levels.py``: level selection, duration, truncation."""
+
+from __future__ import annotations
+
+import pytest
+
+from i_dot_ai_utilities.logging.middleware._levels import (
+    duration_ms,
+    level_for_status,
+    truncate,
+)
+
+
+class TestLevelForStatus:
+    @pytest.mark.parametrize(
+        "status",
+        [200, 201, 204, 299, 300, 301, 302, 399],
+    )
+    def test_info_for_2xx_3xx(self, status):
+        assert level_for_status(status) == "info"
+
+    @pytest.mark.parametrize("status", [400, 401, 403, 404, 429, 499])
+    def test_warning_for_4xx(self, status):
+        assert level_for_status(status) == "warning"
+
+    @pytest.mark.parametrize("status", [500, 502, 503, 504, 599])
+    def test_error_for_5xx(self, status):
+        assert level_for_status(status) == "error"
+
+    @pytest.mark.parametrize("status", [0, 100, 199, 600, 999])
+    def test_unmapped_defaults_to_info(self, status):
+        # Safe default: "don't flood error channels with weird values".
+        assert level_for_status(status) == "info"
+
+
+class TestDurationMs:
+    def test_simple_delta(self):
+        # Use 0.006 to sidestep floating-point precision on 0.005.
+        assert duration_ms(1.0, 1.006) == 6
+
+    def test_zero_delta(self):
+        assert duration_ms(10.0, 10.0) == 0
+
+    def test_sub_millisecond_truncates_to_zero(self):
+        assert duration_ms(1.0, 1.0004) == 0
+
+    def test_negative_delta_clamps_to_zero(self):
+        # Defensive: callers should pass (start, end) in order, but if they
+        # don't, don't corrupt aggregations with negative values.
+        assert duration_ms(2.0, 1.0) == 0
+
+    def test_large_delta(self):
+        # 3.5 seconds.
+        assert duration_ms(0.0, 3.5) == 3500
+
+
+class TestTruncate:
+    def test_shorter_than_limit_unchanged(self):
+        assert truncate("hi", 10) == "hi"
+
+    def test_equal_to_limit_unchanged(self):
+        assert truncate("hello", 5) == "hello"
+
+    def test_longer_than_limit_truncated(self):
+        assert truncate("hello world", 5) == "hello"
+
+    def test_none_passes_through(self):
+        assert truncate(None, 10) is None
+
+    def test_zero_limit(self):
+        assert truncate("foo", 0) == ""
+
+    def test_negative_limit_treated_as_zero(self):
+        assert truncate("foo", -5) == ""

--- a/src/i_dot_ai_utilities/logging/__tests__/test_middleware_settings.py
+++ b/src/i_dot_ai_utilities/logging/__tests__/test_middleware_settings.py
@@ -1,0 +1,327 @@
+# mypy: disable-error-code="no-untyped-def"
+"""Tests for ``middleware._settings``: logger resolution and the bare
+``_BareStructlogAdapter`` fallback.
+
+These tests exist to prevent regression of:
+
+- Security finding A4: ``I_DOT_AI_LOGGER`` MUST refuse dotted-import strings.
+  Accepting them would give anyone able to influence Django settings the
+  ability to import arbitrary modules and invoke their zero-arg callables
+  during middleware boot, code execution at init.
+- Constitution Art. 22: the default logger path MUST NOT call
+  ``structlog.configure()`` (directly or transitively). Doing so globally
+  reconfigures structlog inside an *observability library*, which is
+  widely considered an anti-pattern.
+- The five-method logger contract the middleware writes through
+  (``info``/``warning``/``error``/``exception``/``refresh_context``/
+  ``set_context_field``). The ``_BareStructlogAdapter`` is the default
+  when no ``I_DOT_AI_LOGGER`` is configured; if its behaviour regresses,
+  consumers get silent no-ops.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+import structlog
+
+django = pytest.importorskip("django")
+
+from django.conf import settings as django_settings  # type: ignore[import-untyped]  # noqa: E402
+
+if not django_settings.configured:
+    django_settings.configure(
+        DEBUG=False,
+        ALLOWED_HOSTS=["*"],
+        DATABASES={},
+        INSTALLED_APPS=[],
+        MIDDLEWARE=[],
+        ROOT_URLCONF=__name__,
+        SECRET_KEY="test-secret-not-for-production",
+        USE_TZ=True,
+    )
+    django.setup()
+
+from django.core.exceptions import ImproperlyConfigured  # type: ignore[import-untyped]  # noqa: E402
+
+from i_dot_ai_utilities.logging.middleware._settings import (  # noqa: E402
+    _BareStructlogAdapter,
+    _default_logger,
+    resolve_logger,
+)
+from i_dot_ai_utilities.logging.types.enrichment_types import (  # noqa: E402
+    ContextEnrichmentType,
+)
+
+urlpatterns: list = []
+
+
+# ---------------------------------------------------------------------------
+# Logger doubles
+# ---------------------------------------------------------------------------
+
+
+class _ConformantLogger:
+    """Satisfies the five-method ``_StructuredLoggerLike`` Protocol."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, dict[str, Any]]] = []
+
+    def info(self, message_template: str, **kwargs: Any) -> None:
+        self.calls.append(("info", message_template, kwargs))
+
+    def warning(self, message_template: str, **kwargs: Any) -> None:
+        self.calls.append(("warning", message_template, kwargs))
+
+    def error(self, message_template: str, **kwargs: Any) -> None:
+        self.calls.append(("error", message_template, kwargs))
+
+    def exception(self, message_template: str, **kwargs: Any) -> None:
+        self.calls.append(("exception", message_template, kwargs))
+
+    def refresh_context(
+        self,
+        context_enrichers: Any | None = None,
+        scope: str = "manual",
+    ) -> None:
+        self.calls.append(("refresh_context", scope, {"enrichers": context_enrichers}))
+
+    def set_context_field(self, field_key: str, field_value: Any) -> None:
+        self.calls.append(("set_context_field", field_key, {"value": field_value}))
+
+
+class _NonConformantLogger:
+    """Missing one of the required methods; must be rejected."""
+
+    def info(self, *_a: Any, **_k: Any) -> None:
+        pass
+
+    # no warning / error / exception / refresh_context / set_context_field
+
+
+# ---------------------------------------------------------------------------
+# resolve_logger: security finding A4 + general dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestResolveLogger:
+    def test_dotted_string_is_rejected_with_a4_message(self):
+        """Finding A4: dotted-import strings must never be resolved; that
+        was the previous attack surface allowing arbitrary imports at boot."""
+        with pytest.raises(ImproperlyConfigured) as excinfo:
+            resolve_logger("mypkg.mymodule.build_logger")
+
+        message = str(excinfo.value)
+        # The error message must name the setting AND the remediation path
+        # so operators can act on it without reading source.
+        assert "I_DOT_AI_LOGGER" in message
+        assert "dotted-import string" in message
+        assert "settings.py" in message
+
+    def test_logger_object_passes_through_unchanged(self):
+        logger = _ConformantLogger()
+        assert resolve_logger(logger) is logger
+
+    def test_zero_arg_callable_is_invoked_and_result_returned(self):
+        logger: _ConformantLogger = _ConformantLogger()
+
+        def factory() -> _ConformantLogger:
+            return logger
+
+        resolved = resolve_logger(factory)
+        assert resolved is logger
+
+    def test_callable_returning_non_conformant_object_raises(self):
+        def factory() -> _NonConformantLogger:
+            return _NonConformantLogger()
+
+        with pytest.raises(ImproperlyConfigured) as excinfo:
+            resolve_logger(factory)
+        # Error message names the protocol contract so operators
+        # understand why their logger was refused.
+        msg = str(excinfo.value)
+        assert "not a structured logger" in msg
+        assert "info/warning/error/exception/refresh_context" in msg
+
+    def test_callable_that_raises_is_wrapped_as_improperly_configured(self):
+        class FactoryError(RuntimeError):
+            pass
+
+        def broken_factory() -> Any:
+            msg = "cannot build logger"
+            raise FactoryError(msg)
+
+        with pytest.raises(ImproperlyConfigured) as excinfo:
+            resolve_logger(broken_factory)
+        # The original exception should be chained (Python __cause__)
+        # so tracebacks remain useful, and the outer message should
+        # name the underlying exception class.
+        assert isinstance(excinfo.value.__cause__, FactoryError)
+        assert "FactoryError" in str(excinfo.value)
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            pytest.param(42, id="int"),
+            pytest.param([1, 2, 3], id="list"),
+            pytest.param({"x": 1}, id="dict"),
+        ],
+    )
+    def test_unsupported_type_is_rejected(self, value):
+        with pytest.raises(ImproperlyConfigured) as excinfo:
+            resolve_logger(value)
+        assert "must be a callable or a logger object" in str(excinfo.value)
+
+    def test_none_returns_default_bare_adapter(self):
+        resolved = resolve_logger(None)
+        assert isinstance(resolved, _BareStructlogAdapter)
+
+
+# ---------------------------------------------------------------------------
+# _BareStructlogAdapter: default "no configuration" path
+# ---------------------------------------------------------------------------
+
+
+class TestBareStructlogAdapter:
+    def test_info_warning_error_exception_delegate_through(self):
+        inner = _ConformantLogger()
+        adapter = _BareStructlogAdapter(inner)
+
+        adapter.info("i", a=1)
+        adapter.warning("w", b=2)
+        adapter.error("e", c=3)
+        adapter.exception("x", d=4)
+
+        assert [c[0] for c in inner.calls] == ["info", "warning", "error", "exception"]
+        assert inner.calls[0] == ("info", "i", {"a": 1})
+        assert inner.calls[3] == ("exception", "x", {"d": 4})
+
+    def test_set_context_field_binds_to_structlog_contextvars(self):
+        # Clear any prior state so the assertion is deterministic.
+        structlog.contextvars.clear_contextvars()
+        try:
+            adapter = _BareStructlogAdapter(_ConformantLogger())
+            adapter.set_context_field("tenant_id", "abc-123")
+
+            bound = structlog.contextvars.get_contextvars()
+            assert bound.get("tenant_id") == "abc-123"
+        finally:
+            structlog.contextvars.clear_contextvars()
+
+    def test_refresh_context_with_no_enrichers_clears_contextvars(self):
+        try:
+            structlog.contextvars.bind_contextvars(leftover="value")
+            assert structlog.contextvars.get_contextvars().get("leftover") == "value"
+
+            adapter = _BareStructlogAdapter(_ConformantLogger())
+            adapter.refresh_context()
+
+            assert "leftover" not in structlog.contextvars.get_contextvars()
+        finally:
+            structlog.contextvars.clear_contextvars()
+
+    def test_refresh_context_applies_fastapi_enricher_fields(self):
+        from starlette.datastructures import Headers  # noqa: PLC0415
+        from starlette.requests import Request  # noqa: PLC0415
+
+        scope = {
+            "type": "http",
+            "method": "GET",
+            "path": "/x",
+            "raw_path": b"/x",
+            "query_string": b"q=1",
+            "headers": Headers({"host": "testserver"}).raw,
+            "scheme": "http",
+            "server": ("testserver", 80),
+            "client": ("127.0.0.1", 12345),
+            "http_version": "1.1",
+            "root_path": "",
+        }
+        request = Request(scope)
+
+        try:
+            adapter = _BareStructlogAdapter(_ConformantLogger())
+            adapter.refresh_context(
+                context_enrichers=[
+                    {"type": ContextEnrichmentType.FASTAPI, "object": request},
+                ],
+            )
+
+            bound = structlog.contextvars.get_contextvars()
+            # FastApiEnricher nests HTTP fields under ``request``.
+            assert bound.get("request", {}).get("method") == "GET"
+        finally:
+            structlog.contextvars.clear_contextvars()
+
+    def test_refresh_context_silently_skips_malformed_enrichers(self):
+        """Missing ``type`` or ``object`` keys must be tolerated; copy-paste
+        bugs in consumer code must not take down the request.
+        """
+        try:
+            adapter = _BareStructlogAdapter(_ConformantLogger())
+            adapter.refresh_context(
+                context_enrichers=[
+                    {"type": None, "object": None},  # both missing -> skip
+                    {"object": "no type key"},  # type missing
+                    {"type": ContextEnrichmentType.FASTAPI},  # object missing
+                ],
+            )
+            # No exception raised, no fields bound.
+            assert structlog.contextvars.get_contextvars() == {}
+        finally:
+            structlog.contextvars.clear_contextvars()
+
+    def test_refresh_context_accepts_scope_kwarg_for_parity(self):
+        """The adapter accepts ``scope=...`` but has no ownership registry;
+        this test documents the interface contract."""
+        try:
+            adapter = _BareStructlogAdapter(_ConformantLogger())
+            # Must not raise for any of the known scope values.
+            adapter.refresh_context(scope="request")
+            adapter.refresh_context(scope="job")
+            adapter.refresh_context(scope="manual")
+        finally:
+            structlog.contextvars.clear_contextvars()
+
+
+# ---------------------------------------------------------------------------
+# Default path does not mutate structlog globally (Art. 22)
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultLoggerDoesNotConfigureStructlog:
+    """Constitution Art. 22: the default ``I_DOT_AI_LOGGER`` fallback path
+    MUST NOT call ``structlog.configure()``. Doing so from inside an
+    observability library silently overrides the consumer's own structlog
+    setup, an anti-pattern that has bitten us before.
+    """
+
+    def test_default_logger_does_not_call_structlog_configure(self):
+        with patch.object(structlog, "configure") as spy:
+            logger = _default_logger()
+            assert isinstance(logger, _BareStructlogAdapter)
+            assert spy.call_count == 0
+
+    def test_resolve_logger_none_does_not_call_structlog_configure(self):
+        """Same invariant via the public entry point."""
+        with patch.object(structlog, "configure") as spy:
+            resolved = resolve_logger(None)
+            assert isinstance(resolved, _BareStructlogAdapter)
+            assert spy.call_count == 0
+
+    def test_default_logger_exposes_five_method_contract(self):
+        """Smoke test: the default adapter must be usable end-to-end by the
+        middleware without raising AttributeError."""
+        logger = _default_logger()
+
+        # Each of these is called by ``StructuredLoggingMiddlewareOTel`` at
+        # some point in a request lifecycle; if any is missing the
+        # middleware would crash at runtime.
+        logger.info("hello")
+        logger.warning("hello")
+        logger.error("hello")
+        logger.exception("hello")
+        logger.set_context_field("k", "v")
+        logger.refresh_context()

--- a/src/i_dot_ai_utilities/logging/__tests__/test_middleware_settings.py
+++ b/src/i_dot_ai_utilities/logging/__tests__/test_middleware_settings.py
@@ -8,7 +8,7 @@ These tests exist to prevent regression of:
   Accepting them would give anyone able to influence Django settings the
   ability to import arbitrary modules and invoke their zero-arg callables
   during middleware boot, code execution at init.
-- Constitution Art. 22: the default logger path MUST NOT call
+- the default logger path MUST NOT call
   ``structlog.configure()`` (directly or transitively). Doing so globally
   reconfigures structlog inside an *observability library*, which is
   widely considered an anti-pattern.
@@ -102,7 +102,7 @@ class _NonConformantLogger:
 
 
 # ---------------------------------------------------------------------------
-# resolve_logger: security finding A4 + general dispatch
+# resolve_logger: dotted-import-string rejection + general dispatch
 # ---------------------------------------------------------------------------
 
 
@@ -287,12 +287,12 @@ class TestBareStructlogAdapter:
 
 
 # ---------------------------------------------------------------------------
-# Default path does not mutate structlog globally (Art. 22)
+# Default path does not mutate structlog globally
 # ---------------------------------------------------------------------------
 
 
 class TestDefaultLoggerDoesNotConfigureStructlog:
-    """Constitution Art. 22: the default ``I_DOT_AI_LOGGER`` fallback path
+    """the default ``I_DOT_AI_LOGGER`` fallback path
     MUST NOT call ``structlog.configure()``. Doing so from inside an
     observability library silently overrides the consumer's own structlog
     setup, an anti-pattern that has bitten us before.

--- a/src/i_dot_ai_utilities/logging/__tests__/test_optional_django_import.py
+++ b/src/i_dot_ai_utilities/logging/__tests__/test_optional_django_import.py
@@ -1,7 +1,7 @@
 # mypy: disable-error-code="no-untyped-def"
 """Tests verifying the library's soft-Django-dependency contract.
 
-The constitution requires that:
+The optional-import contract requires that:
 
 - ``i_dot_ai_utilities.logging`` and ``i_dot_ai_utilities.logging.middleware``
   are importable in an environment without Django.

--- a/src/i_dot_ai_utilities/logging/__tests__/test_optional_django_import.py
+++ b/src/i_dot_ai_utilities/logging/__tests__/test_optional_django_import.py
@@ -1,0 +1,140 @@
+# mypy: disable-error-code="no-untyped-def"
+"""Tests verifying the library's soft-Django-dependency contract.
+
+The constitution requires that:
+
+- ``i_dot_ai_utilities.logging`` and ``i_dot_ai_utilities.logging.middleware``
+  are importable in an environment without Django.
+- The Django-specific modules (``middleware.django_otel`` and
+  ``middleware.django_user_id``) do not execute any Django imports at
+  module-load time in a way that would crash pure-Python imports of the
+  rest of the library; importing them in a Django-free env surfaces an
+  ImportError mentioning ``django`` cleanly.
+
+We simulate "Django not installed" by running child Python subprocesses that
+inject a ``sys.meta_path`` finder blocking any import that targets Django.
+Uses the modern ``find_spec`` protocol so the block is enforced under
+Python 3.12+ (where legacy ``find_module`` is a no-op).
+"""
+
+from __future__ import annotations
+
+import pathlib
+import subprocess
+import sys
+
+_DJANGO_BLOCK_SETUP = (
+    "import sys\n"
+    "class _BlockDjango:\n"
+    "    def find_spec(self, name, path=None, target=None):\n"
+    "        if name == 'django' or name.startswith('django.'):\n"
+    "            raise ImportError('No module named ' + name + ' (blocked for test)')\n"
+    "        return None\n"
+    "sys.meta_path.insert(0, _BlockDjango())\n"
+    "for k in list(sys.modules):\n"
+    "    if k == 'django' or k.startswith('django.'):\n"
+    "        del sys.modules[k]\n"
+)
+
+
+def _run_child(script: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(  # noqa: S603
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_logging_package_and_middleware_subpackage_importable_without_django():
+    """Root logging imports must work without Django installed."""
+    body = (
+        "try:\n"
+        "    import django\n"
+        "    raise SystemExit('block failed: django importable')\n"
+        "except ImportError:\n"
+        "    pass\n"
+        "import i_dot_ai_utilities\n"
+        "import i_dot_ai_utilities.logging\n"
+        "import i_dot_ai_utilities.logging.middleware\n"
+        "from i_dot_ai_utilities.logging.structured_logger import StructuredLogger\n"
+        "from i_dot_ai_utilities.logging.middleware._exclusions import ExclusionMatcher\n"
+        "from i_dot_ai_utilities.logging.middleware._levels import level_for_status\n"
+        "from i_dot_ai_utilities.logging.middleware._headers import X_REQUEST_ID, validate_request_id\n"
+        "from i_dot_ai_utilities.logging.middleware._settings import resolve_logger\n"
+        "print('OK')\n"
+    )
+    script = _DJANGO_BLOCK_SETUP + body
+    result = _run_child(script)
+    assert result.returncode == 0, f"import failed. stdout={result.stdout!r} stderr={result.stderr!r}"
+    assert "OK" in result.stdout
+
+
+def test_middleware_django_otel_module_requires_django_to_import():
+    """Importing ``middleware.django_otel`` fails cleanly without Django.
+
+    Django imports live at module top level in the Django-specific
+    submodules; this is the intended design (see anti-patterns brief §F.3:
+    lazy imports inside ``__call__`` obscure the dependency graph and buy
+    nothing when the containing module is by definition Django-specific).
+    Importing either of them without Django must therefore surface an
+    ImportError mentioning ``django``, not a confusing error from our own
+    package.
+    """
+    body = (
+        "try:\n"
+        "    import i_dot_ai_utilities.logging.middleware.django_otel  # noqa: F401\n"
+        "except ImportError as exc:\n"
+        "    if 'django' not in str(exc).lower():\n"
+        "        raise SystemExit('unexpected error: ' + str(exc))\n"
+        "    print('OK')\n"
+        "else:\n"
+        "    raise SystemExit('import succeeded without Django')\n"
+    )
+    script = _DJANGO_BLOCK_SETUP + body
+    result = _run_child(script)
+    assert result.returncode == 0, f"unexpected behaviour. stdout={result.stdout!r} stderr={result.stderr!r}"
+    assert "OK" in result.stdout
+
+
+def test_middleware_django_user_id_module_requires_django_to_import():
+    body = (
+        "try:\n"
+        "    import i_dot_ai_utilities.logging.middleware.django_user_id  # noqa: F401\n"
+        "except ImportError as exc:\n"
+        "    if 'django' not in str(exc).lower():\n"
+        "        raise SystemExit('unexpected error: ' + str(exc))\n"
+        "    print('OK')\n"
+        "else:\n"
+        "    raise SystemExit('import succeeded without Django')\n"
+    )
+    script = _DJANGO_BLOCK_SETUP + body
+    result = _run_child(script)
+    assert result.returncode == 0, f"unexpected behaviour. stdout={result.stdout!r} stderr={result.stderr!r}"
+    assert "OK" in result.stdout
+
+
+def test_no_django_imports_at_top_of_logging_modules():
+    """Defence in depth: verify source files do not grep-positive for top-level
+    Django imports outside the Django-specific submodules.
+    """
+    logging_root = pathlib.Path(__file__).resolve().parents[1]
+    allowed = {
+        # OTel-backed Django middleware; Django imports at module top level
+        # are allowed because this module is by definition Django-specific.
+        logging_root / "middleware" / "django_otel.py",
+        # Thin middleware that binds user.id onto the log context; same
+        # design intent.
+        logging_root / "middleware" / "django_user_id.py",
+    }
+
+    offenders: list[str] = []
+    for py in logging_root.rglob("*.py"):
+        if py in allowed:
+            continue
+        if "__tests__" in py.parts:
+            continue
+        for line in py.read_text().splitlines():
+            if line.startswith(("import django", "from django")):
+                offenders.append(f"{py}: {line!r}")
+    assert not offenders, "Top-level Django imports outside Django-specific modules: " + "; ".join(offenders)

--- a/src/i_dot_ai_utilities/logging/_limits.py
+++ b/src/i_dot_ai_utilities/logging/_limits.py
@@ -1,0 +1,37 @@
+"""Shared size caps and truncation helper.
+
+Centralised here so both the middleware (``middleware/*``) and the enricher
+(``enrichers/django_enricher``) can apply the same ingest-time bounds without
+reaching across subpackage boundaries into the middleware module.
+
+Pure Python, no third-party imports, no side effects on import, so it is safe to
+import in non-Django consumers (verified by ``test_optional_django_import``).
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+# Size caps. Deliberately small: log ingestion is vastly cheaper when fields
+# are bounded, and uncapped values turn pathological inputs (multi-MB
+# User-Agent strings, absurd query strings) into multi-MB log lines.
+MAX_HEADER_VALUE: Final[int] = 512
+MAX_URL_PATH: Final[int] = 2048
+MAX_URL_QUERY: Final[int] = 1024
+MAX_REQUEST_ID: Final[int] = 200
+
+
+def truncate(value: str | None, limit: int) -> str | None:
+    """Truncate a string to ``limit`` chars, passing ``None`` through unchanged.
+
+    No truncation marker is appended, since we want the field to stay bounded even
+    if consumers concatenate it with other data downstream. The caller can add
+    a marker if it wants to indicate truncation.
+    """
+    if value is None:
+        return None
+    if limit <= 0:
+        return ""
+    if len(value) <= limit:
+        return value
+    return value[:limit]

--- a/src/i_dot_ai_utilities/logging/_otel/__init__.py
+++ b/src/i_dot_ai_utilities/logging/_otel/__init__.py
@@ -1,0 +1,44 @@
+"""OpenTelemetry integration subpackage for the logging module.
+
+Public entry points:
+
+- :func:`configure_otel`: framework-neutral bootstrap (traces/metrics/logs).
+- :func:`configure_otel_for_django`: Django auto-instrumentation wrapper.
+- :func:`configure_otel_for_fastapi`: FastAPI/ASGI auto-instrumentation wrapper.
+- :func:`otel_trace_context_processor`: structlog processor injecting
+  ``trace_id`` / ``span_id`` / ``trace_flags`` from the active span.
+- :func:`build_composite_propagator`: W3C + AWS X-Ray composite textmap.
+
+Requires the ``[otel]`` optional extra. Importing this subpackage without
+``opentelemetry-*`` installed raises ``ImportError`` at module load, kept
+deliberately noisy so misconfiguration is caught during startup rather
+than silently at first-request time.
+"""
+
+from __future__ import annotations
+
+from i_dot_ai_utilities.logging._otel.propagators import build_composite_propagator
+from i_dot_ai_utilities.logging._otel.setup import (
+    configure_otel,
+    configure_otel_for_django,
+    configure_otel_for_fastapi,
+    configure_otel_for_lambda,
+    ensure_structlog_otel_processors,
+    force_flush_otel,
+    insert_trace_processor,
+)
+from i_dot_ai_utilities.logging._otel.structlog_processor import (
+    otel_trace_context_processor,
+)
+
+__all__ = [
+    "build_composite_propagator",
+    "configure_otel",
+    "configure_otel_for_django",
+    "configure_otel_for_fastapi",
+    "configure_otel_for_lambda",
+    "ensure_structlog_otel_processors",
+    "force_flush_otel",
+    "insert_trace_processor",
+    "otel_trace_context_processor",
+]

--- a/src/i_dot_ai_utilities/logging/_otel/otlp_log_processor.py
+++ b/src/i_dot_ai_utilities/logging/_otel/otlp_log_processor.py
@@ -1,0 +1,58 @@
+"""Best-effort OTLP log emit from structlog events."""
+
+from __future__ import annotations
+
+import contextlib
+import time
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import MutableMapping
+
+
+def otel_otlp_log_emitter_processor(
+    _logger: Any,
+    method_name: str,
+    event_dict: MutableMapping[str, Any],
+) -> MutableMapping[str, Any]:
+    """Emit an OTLP log record; never raise into the structlog pipeline."""
+    with contextlib.suppress(Exception):
+        from opentelemetry import context as otel_context  # noqa: PLC0415
+        from opentelemetry._logs import LogRecord, SeverityNumber, get_logger  # noqa: PLC0415
+
+        severity_map = {
+            "debug": SeverityNumber.DEBUG,
+            "info": SeverityNumber.INFO,
+            "warning": SeverityNumber.WARN,
+            "warn": SeverityNumber.WARN,
+            "error": SeverityNumber.ERROR,
+            "exception": SeverityNumber.ERROR,
+            "critical": SeverityNumber.FATAL,
+            "fatal": SeverityNumber.FATAL,
+        }
+        level = str(event_dict.get("level", method_name)).lower()
+        body = str(event_dict.get("event") or event_dict.get("message") or "")
+        attrs: dict[str, Any] = {}
+        for key, value in event_dict.items():
+            if key in {"event", "message", "level", "timestamp", "_record", "_from_structlog"}:
+                continue
+            if isinstance(value, str | int | float | bool):
+                attrs[key] = value
+
+        # Logger.emit(record) is the only signature the OTel API defines. Passing
+        # context lets the SDK correlate the log to the active span (trace_id/span_id).
+        # timestamp must be set: the SDK leaves Timestamp unset → OTLP time_unix_nano=0
+        # → OpenSearch @timestamp=1970 when the exporter maps Timestamp only.
+        record = LogRecord(
+            timestamp=time.time_ns(),
+            context=otel_context.get_current(),
+            body=body,
+            severity_text=level.upper(),
+            severity_number=severity_map.get(level, SeverityNumber.INFO),
+            attributes=attrs,
+        )
+        get_logger("i_dot_ai_utilities.logging").emit(record)
+    return event_dict
+
+
+__all__ = ["otel_otlp_log_emitter_processor"]

--- a/src/i_dot_ai_utilities/logging/_otel/propagators.py
+++ b/src/i_dot_ai_utilities/logging/_otel/propagators.py
@@ -1,0 +1,46 @@
+"""Composite OTel propagator for the Django OTel middleware.
+
+Builds a :class:`CompositePropagator` chaining W3C Trace Context and AWS
+X-Ray, arranged so W3C wins when both headers are present on the same
+inbound request. Mirrors the precedence historically enforced by the
+library's own header-parsing path, now delegated entirely to OTel.
+
+``X-Request-ID`` is intentionally **not** included in the propagator
+chain. The middleware treats it as an opaque per-hop correlation id
+(never as a W3C trace): ``request_id`` is bound onto the log context by
+the middleware itself, not by span context.
+
+Pure wiring module: no module-level side effects, no global propagator
+mutation. ``set_global_textmap`` is called exclusively from
+``setup.configure_otel_for_django``.
+"""
+
+from __future__ import annotations
+
+from opentelemetry.propagators.aws import AwsXRayPropagator
+from opentelemetry.propagators.composite import CompositePropagator
+from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
+
+
+def build_composite_propagator() -> CompositePropagator:
+    """Return a composite propagator giving W3C Trace Context precedence.
+
+    Ordering is significant. :class:`CompositePropagator` runs every
+    propagator on ``extract`` and the **last** propagator to write a
+    context key wins. To match the existing middleware's precedence
+    (W3C beats X-Ray when both headers are present), X-Ray runs first
+    and W3C runs last.
+
+    Both propagators still contribute on ``inject``, so outbound
+    requests carry both ``traceparent`` and ``X-Amzn-Trace-Id``
+    regardless of order.
+    """
+    return CompositePropagator(
+        [
+            AwsXRayPropagator(),
+            TraceContextTextMapPropagator(),
+        ]
+    )
+
+
+__all__ = ["build_composite_propagator"]

--- a/src/i_dot_ai_utilities/logging/_otel/setup.py
+++ b/src/i_dot_ai_utilities/logging/_otel/setup.py
@@ -1,0 +1,437 @@
+"""Framework-neutral OpenTelemetry bootstrap for i-dot-ai services.
+
+``configure_otel`` is the single entrypoint for traces, metrics, and optional
+log-bridge wiring. Framework helpers (``configure_otel_for_django``,
+``configure_otel_for_fastapi``) call into it and enable auto-instrumentation.
+
+Behaviour guarantees:
+
+- Idempotent within a process (safe to call from AppConfig.ready / ASGI lifespan).
+- X-Ray-compatible trace IDs via ``AwsXRayIdGenerator`` when available.
+- Composite W3C + AWS X-Ray propagator (W3C wins on extract conflict).
+- Resource attributes follow Semantic Conventions (``service.name``,
+  ``deployment.environment.name``, optional ``service.version``).
+- Legacy ``configure_otel_for_django`` remains a compatible wrapper.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+from typing import TYPE_CHECKING, Any
+
+from opentelemetry import metrics, trace
+from opentelemetry.propagate import set_global_textmap
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
+
+from i_dot_ai_utilities.logging._otel.otlp_log_processor import (
+    otel_otlp_log_emitter_processor,
+)
+from i_dot_ai_utilities.logging._otel.propagators import build_composite_propagator
+from i_dot_ai_utilities.logging._otel.structlog_processor import (
+    otel_trace_context_processor,
+)
+
+if TYPE_CHECKING:
+    from opentelemetry.sdk.trace.export import SpanExporter
+
+_django_instrumented: bool = False
+_fastapi_instrumented: bool = False
+_configured: bool = False
+_tracer_provider: TracerProvider | None = None
+
+
+def _build_resource(service_name: str) -> Resource:
+    """Compose a Semantic-Convention Resource for the process."""
+    attrs: dict[str, Any] = {"service.name": service_name}
+    version = os.environ.get("APP_VERSION") or os.environ.get("OTEL_SERVICE_VERSION")
+    if version:
+        attrs["service.version"] = version
+    environment = os.environ.get("OTEL_RESOURCE_ATTRIBUTES", "")
+    env_name = os.environ.get("DEPLOYMENT_ENVIRONMENT") or os.environ.get("ENVIRONMENT")
+    if "deployment.environment.name=" in environment:
+        for part in environment.split(","):
+            if part.startswith("deployment.environment.name="):
+                env_name = part.split("=", 1)[1]
+                break
+    if env_name:
+        attrs["deployment.environment.name"] = env_name
+        # Do not dual-write legacy ``deployment.environment``: OpenSearch treats
+        # dotted keys as nested paths, so emitting both that key and
+        # ``deployment.environment.name`` causes permanent mapping conflicts.
+    namespace = os.environ.get("SERVICE_NAMESPACE")
+    if not namespace and "service.namespace=" in environment:
+        for part in environment.split(","):
+            if part.startswith("service.namespace="):
+                namespace = part.split("=", 1)[1]
+                break
+    if namespace:
+        attrs["service.namespace"] = namespace
+    return Resource.create(attrs)
+
+
+def _build_id_generator() -> Any | None:
+    """Return an X-Ray-compatible IdGenerator when the AWS extension is installed."""
+    with contextlib.suppress(ImportError):
+        from opentelemetry.sdk.extension.aws.trace import AwsXRayIdGenerator  # noqa: PLC0415
+
+        return AwsXRayIdGenerator()
+    return None
+
+
+def _otlp_exporter_kwargs(signal_path: str) -> dict[str, Any] | None:
+    """Build shared OTLP HTTP exporter kwargs for one signal.
+
+    Single source of truth for endpoint suffixing and header propagation so
+    traces, metrics, and logs cannot drift apart (e.g. authenticated traces
+    but unauthenticated logs/metrics).
+    """
+    endpoint = os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT")
+    if not endpoint:
+        return None
+    signal_endpoint = endpoint.rstrip("/")
+    if not signal_endpoint.endswith(signal_path):
+        signal_endpoint = f"{signal_endpoint}{signal_path}"
+    kwargs: dict[str, Any] = {"endpoint": signal_endpoint}
+    headers = _otlp_headers_from_env()
+    if headers:
+        kwargs["headers"] = headers
+    return kwargs
+
+
+def _default_otlp_span_exporter() -> SpanExporter | None:
+    """Build an OTLP HTTP span exporter from env, or None if unset."""
+    kwargs = _otlp_exporter_kwargs("/v1/traces")
+    if kwargs is None:
+        return None
+    with contextlib.suppress(ImportError):
+        from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter  # noqa: PLC0415
+
+        return OTLPSpanExporter(**kwargs)
+    return None
+
+
+def _otlp_headers_from_env() -> dict[str, str] | None:
+    """Parse OTEL_EXPORTER_OTLP_HEADERS (comma-separated key=value)."""
+    raw = os.environ.get("OTEL_EXPORTER_OTLP_HEADERS")
+    if not raw:
+        return None
+    headers: dict[str, str] = {}
+    for part in raw.split(","):
+        if "=" not in part:
+            continue
+        key, value = part.split("=", 1)
+        headers[key.strip()] = value.strip()
+    return headers or None
+
+
+def _require_otlp_endpoint_or_raise() -> None:
+    """Fail visibly in AWS when OTLP endpoint is required but missing."""
+    require = os.environ.get("OTEL_REQUIRE_ENDPOINT", "").lower() in {"1", "true", "yes"}
+    if require and not os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT"):
+        msg = (
+            "OTEL_REQUIRE_ENDPOINT is set but OTEL_EXPORTER_OTLP_ENDPOINT is missing. "
+            "Refusing silent console/localhost export."
+        )
+        raise RuntimeError(msg)
+
+
+def _configure_metrics(resource: Resource) -> None:
+    """Install a MeterProvider with OTLP export when the exporter is available."""
+    kwargs = _otlp_exporter_kwargs("/v1/metrics")
+    if kwargs is None:
+        return
+    try:
+        from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter  # noqa: PLC0415
+        from opentelemetry.sdk.metrics import MeterProvider  # noqa: PLC0415
+        from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader  # noqa: PLC0415
+
+        reader = PeriodicExportingMetricReader(
+            OTLPMetricExporter(**kwargs),
+            export_interval_millis=10000,
+        )
+        provider = MeterProvider(resource=resource, metric_readers=[reader])
+        metrics.set_meter_provider(provider)
+    except Exception:  # noqa: BLE001 - bootstrap must not crash the app
+        import logging  # noqa: PLC0415
+
+        # Warn (don't suppress silently) so a misconfigured/missing metric
+        # exporter is visible rather than exporting traces fine while emitting
+        # no metrics at all.
+        logging.getLogger(__name__).warning("OTLP metrics not configured", exc_info=True)
+
+
+def _configure_logs_bridge(resource: Resource) -> None:
+    """Install LoggerProvider + OTLP exporter so structlog can emit OTLP logs."""
+    kwargs = _otlp_exporter_kwargs("/v1/logs")
+    if kwargs is None:
+        return
+    try:
+        import logging  # noqa: PLC0415
+
+        from opentelemetry._logs import set_logger_provider  # noqa: PLC0415
+        from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter  # noqa: PLC0415
+        from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler  # noqa: PLC0415
+        from opentelemetry.sdk._logs.export import BatchLogRecordProcessor  # noqa: PLC0415
+
+        provider = LoggerProvider(resource=resource)
+        provider.add_log_record_processor(BatchLogRecordProcessor(OTLPLogExporter(**kwargs)))
+        set_logger_provider(provider)
+        # Stdlib bridge for code paths that use logging.getLogger().
+        handler = LoggingHandler(level=logging.NOTSET, logger_provider=provider)
+        logging.getLogger().addHandler(handler)
+    except Exception:  # noqa: BLE001 - bootstrap must not crash the app
+        import logging  # noqa: PLC0415
+
+        logging.getLogger(__name__).warning("OTLP logs bridge not configured", exc_info=True)
+
+
+def _insert_trace_processor(processors: list[Any]) -> list[Any]:
+    # Trace context must precede the log emitter so emitted OTLP logs carry
+    # trace_id/span_id; both go before the renderer (assumed last).
+    new_processors = list(processors)
+    to_add = [
+        proc for proc in (otel_trace_context_processor, otel_otlp_log_emitter_processor) if proc not in new_processors
+    ]
+    insert_at = max(len(new_processors) - 1, 0)
+    new_processors[insert_at:insert_at] = to_add
+    return new_processors
+
+
+def _build_default_tracer_provider(
+    resource: Resource,
+    span_exporter: SpanExporter | None,
+) -> TracerProvider:
+    """Build the process TracerProvider with an OTLP (or console) exporter."""
+    id_generator = _build_id_generator()
+    kwargs: dict[str, Any] = {"resource": resource}
+    if id_generator is not None:
+        kwargs["id_generator"] = id_generator
+    provider = TracerProvider(**kwargs)
+
+    exporter = span_exporter if span_exporter is not None else _default_otlp_span_exporter()
+    if exporter is None:
+        if os.environ.get("OTEL_REQUIRE_ENDPOINT", "").lower() in {"1", "true", "yes"}:
+            msg = "OTLP span exporter unavailable despite required endpoint"
+            raise RuntimeError(msg)
+        exporter = ConsoleSpanExporter()
+    provider.add_span_processor(BatchSpanProcessor(exporter))
+    return provider
+
+
+def _apply_trace_processor(structlog_processors: list[Any]) -> None:
+    """Insert the trace-context processor into the caller's processor list in place."""
+    updated = _insert_trace_processor(structlog_processors)
+    structlog_processors.clear()
+    structlog_processors.extend(updated)
+
+
+def configure_otel(
+    *,
+    service_name: str,
+    span_exporter: SpanExporter | None = None,
+    structlog_processors: list[Any] | None = None,
+    install_global_propagator: bool = True,
+    tracer_provider: TracerProvider | None = None,
+    enable_metrics: bool = True,
+    enable_log_bridge: bool = True,
+) -> TracerProvider:
+    """Configure OpenTelemetry for any runtime.
+
+    :param service_name: Bound to ``service.name`` on every signal.
+    :param span_exporter: Defaults to OTLP from env, else ConsoleSpanExporter.
+    :param structlog_processors: Optional list mutated to include the
+        trace-context processor before the renderer.
+    :param install_global_propagator: Install W3C+X-Ray composite propagator.
+    :param tracer_provider: Optional pre-built provider (tests).
+    :param enable_metrics: Install OTLP MeterProvider when env endpoint is set.
+    :param enable_log_bridge: Attach OTel LoggingHandler for OTLP logs.
+    :returns: The installed ``TracerProvider``.
+    """
+    global _configured, _tracer_provider  # noqa: PLW0603
+
+    _require_otlp_endpoint_or_raise()
+
+    if _configured and _tracer_provider is not None:
+        # Idempotent within a process: providers, the global propagator, and
+        # the stdlib log bridge are installed once. Re-running the tracer
+        # block would build a second TracerProvider + BatchSpanProcessor
+        # (leaking an export thread) that trace.set_tracer_provider() then
+        # refuses to install, since it is set-once. Return the provider that
+        # is actually installed so re-invocation from wsgi.py/asgi.py is safe.
+        if structlog_processors is not None:
+            _apply_trace_processor(structlog_processors)
+        return _tracer_provider
+
+    resource = _build_resource(service_name)
+
+    if tracer_provider is None:
+        tracer_provider = _build_default_tracer_provider(resource, span_exporter)
+
+    trace.set_tracer_provider(tracer_provider)
+
+    if install_global_propagator:
+        set_global_textmap(build_composite_propagator())
+
+    if enable_metrics:
+        _configure_metrics(resource)
+    if enable_log_bridge:
+        _configure_logs_bridge(resource)
+
+    if structlog_processors is not None:
+        _apply_trace_processor(structlog_processors)
+
+    _tracer_provider = tracer_provider
+    _configured = True
+    return tracer_provider
+
+
+def configure_otel_for_django(
+    *,
+    service_name: str,
+    span_exporter: SpanExporter | None = None,
+    structlog_processors: list[Any] | None = None,
+    install_global_propagator: bool = True,
+    tracer_provider: TracerProvider | None = None,
+) -> TracerProvider:
+    """Configure OpenTelemetry tracing for a Django service (compatible wrapper)."""
+    global _django_instrumented  # noqa: PLW0603
+
+    provider = configure_otel(
+        service_name=service_name,
+        span_exporter=span_exporter,
+        structlog_processors=structlog_processors,
+        install_global_propagator=install_global_propagator,
+        tracer_provider=tracer_provider,
+        enable_metrics=True,
+        enable_log_bridge=True,
+    )
+
+    if not _django_instrumented:
+        from opentelemetry.instrumentation.django import DjangoInstrumentor  # noqa: PLC0415
+
+        DjangoInstrumentor().instrument(tracer_provider=provider)
+        _django_instrumented = True
+
+    return provider
+
+
+def configure_otel_for_fastapi(
+    *,
+    service_name: str,
+    app: Any | None = None,
+    span_exporter: SpanExporter | None = None,
+    structlog_processors: list[Any] | None = None,
+    install_global_propagator: bool = True,
+    tracer_provider: TracerProvider | None = None,
+) -> TracerProvider:
+    """Configure OpenTelemetry for a FastAPI/ASGI application."""
+    global _fastapi_instrumented  # noqa: PLW0603
+
+    provider = configure_otel(
+        service_name=service_name,
+        span_exporter=span_exporter,
+        structlog_processors=structlog_processors,
+        install_global_propagator=install_global_propagator,
+        tracer_provider=tracer_provider,
+        enable_metrics=True,
+        enable_log_bridge=True,
+    )
+
+    if not _fastapi_instrumented:
+        with contextlib.suppress(ImportError):
+            from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor  # noqa: PLC0415
+
+            if app is not None:
+                FastAPIInstrumentor.instrument_app(app, tracer_provider=provider)
+            else:
+                FastAPIInstrumentor().instrument(tracer_provider=provider)
+            _fastapi_instrumented = True
+
+    return provider
+
+
+def insert_trace_processor(processors: list[Any]) -> list[Any]:
+    """Return ``processors`` with the trace-context processor inserted."""
+    return _insert_trace_processor(processors)
+
+
+def ensure_structlog_otel_processors() -> None:
+    """Re-insert OTel processors after StructuredLogger resets structlog config.
+
+    Call once after constructing ``StructuredLogger`` so apps do not need to
+    hand-roll processor list surgery.
+    """
+    with contextlib.suppress(Exception):
+        import structlog  # noqa: PLC0415
+
+        current = list(structlog.get_config().get("processors", []))
+        updated = _insert_trace_processor(current)
+        structlog.configure(processors=updated)
+
+
+def configure_otel_for_lambda(
+    *,
+    service_name: str,
+    span_exporter: SpanExporter | None = None,
+) -> TracerProvider:
+    """Bootstrap OTel for a short-lived Lambda handler.
+
+    Sets a process-wide provider. Call :func:`force_flush_otel` at the end of
+    each invocation (or use the AWS Lambda instrumentation layer separately).
+    """
+    os.environ.setdefault("OTEL_REQUIRE_ENDPOINT", "1")
+    return configure_otel(
+        service_name=service_name,
+        span_exporter=span_exporter,
+        enable_metrics=True,
+        enable_log_bridge=True,
+    )
+
+
+def force_flush_otel(timeout_millis: int = 5000) -> None:
+    """Flush traces/metrics/logs providers, required for Lambda/Batch exit."""
+    with contextlib.suppress(Exception):
+        provider = trace.get_tracer_provider()
+        if hasattr(provider, "force_flush"):
+            provider.force_flush(timeout_millis)
+    with contextlib.suppress(Exception):
+        meter = metrics.get_meter_provider()
+        if hasattr(meter, "force_flush"):
+            meter.force_flush(timeout_millis)
+    with contextlib.suppress(Exception):
+        from opentelemetry._logs import get_logger_provider  # noqa: PLC0415
+
+        logs_provider = get_logger_provider()
+        if hasattr(logs_provider, "force_flush"):
+            logs_provider.force_flush(timeout_millis)
+
+
+def _reset_for_tests() -> None:
+    """Reset module-level instrumentation flags (tests only)."""
+    global _django_instrumented, _fastapi_instrumented, _configured, _tracer_provider  # noqa: PLW0603
+    with contextlib.suppress(Exception):
+        from opentelemetry.instrumentation.django import DjangoInstrumentor  # noqa: PLC0415
+
+        DjangoInstrumentor().uninstrument()
+    with contextlib.suppress(Exception):
+        from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor  # noqa: PLC0415
+
+        FastAPIInstrumentor().uninstrument()
+    _django_instrumented = False
+    _fastapi_instrumented = False
+    _configured = False
+    _tracer_provider = None
+
+
+__all__ = [
+    "configure_otel",
+    "configure_otel_for_django",
+    "configure_otel_for_fastapi",
+    "configure_otel_for_lambda",
+    "ensure_structlog_otel_processors",
+    "force_flush_otel",
+    "insert_trace_processor",
+]

--- a/src/i_dot_ai_utilities/logging/_otel/structlog_processor.py
+++ b/src/i_dot_ai_utilities/logging/_otel/structlog_processor.py
@@ -1,0 +1,73 @@
+"""Structlog processor that injects OTel trace context into every log event.
+
+Replaces the existing middleware's per-lifecycle-event ``set_context_field``
+calls for ``trace_id`` / ``span_id`` / ``trace_flags``. Because the processor
+runs on *every* event in the structlog pipeline, any log line emitted inside
+a Django request (not just ``request_started`` / ``request_completed``)
+gets trace correlation automatically.
+
+Field names and encodings follow the OTel logs data model:
+
+- ``trace_id``: 32 lowercase hex chars
+- ``span_id``: 16 lowercase hex chars
+- ``trace_flags``: 2 lowercase hex chars
+
+Keys are omitted entirely when there is no active span (matching the
+existing middleware's "don't emit empty values" contract). Outside a span
+context, downstream consumers should query with ``has(trace_id)`` rather
+than ``trace_id=""``.
+
+Pure Python module: imports only ``opentelemetry.trace``. No side effects
+on import.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from typing import TYPE_CHECKING, Any
+
+from opentelemetry import trace
+
+if TYPE_CHECKING:
+    from collections.abc import MutableMapping
+
+
+_TRACE_ID_HEX_LEN = 32
+_SPAN_ID_HEX_LEN = 16
+_TRACE_FLAGS_HEX_LEN = 2
+
+
+def otel_trace_context_processor(
+    _logger: Any,
+    _method_name: str,
+    event_dict: MutableMapping[str, Any],
+) -> MutableMapping[str, Any]:
+    """Inject ``trace_id`` / ``span_id`` / ``trace_flags`` from the active span.
+
+    Signature matches the structlog processor contract
+    (``logger, method_name, event_dict``). Mutates and returns ``event_dict``
+    in place, as is idiomatic for structlog processors.
+
+    Behaviour:
+
+    - Active, recording, valid span context: all three keys are injected.
+    - No active span, or non-recording span, or invalid span context: all
+      three keys are omitted. Pre-existing ``trace_id`` / ``span_id`` /
+      ``trace_flags`` entries in the event dict are left untouched on the
+      absence path so the processor is non-destructive.
+    - Unexpected exception while reading the span context: swallowed. An
+      observability helper must never take a log line down; the worst case
+      is we lose trace correlation for a single event, not that the event
+      goes unlogged.
+    """
+    with contextlib.suppress(Exception):
+        span = trace.get_current_span()
+        ctx = span.get_span_context()
+        if ctx.is_valid:
+            event_dict["trace_id"] = format(ctx.trace_id, f"0{_TRACE_ID_HEX_LEN}x")
+            event_dict["span_id"] = format(ctx.span_id, f"0{_SPAN_ID_HEX_LEN}x")
+            event_dict["trace_flags"] = format(ctx.trace_flags, f"0{_TRACE_FLAGS_HEX_LEN}x")
+    return event_dict
+
+
+__all__ = ["otel_trace_context_processor"]

--- a/src/i_dot_ai_utilities/logging/middleware/__init__.py
+++ b/src/i_dot_ai_utilities/logging/middleware/__init__.py
@@ -1,0 +1,10 @@
+"""Django integration middleware for the structured logger.
+
+This subpackage holds Django-specific code. The library treats Django as a
+soft optional dependency: install with ``pip install "i-dot-ai-utilities[django]"``.
+
+Only the concrete Django modules (``i_dot_ai_utilities.logging.middleware.django_otel``
+and ``i_dot_ai_utilities.logging.middleware.django_user_id``) import Django.
+The helpers in this subpackage (``_headers``, ``_exclusions``, ``_levels``,
+``_settings``) are pure Python and safe to import in non-Django consumers.
+"""

--- a/src/i_dot_ai_utilities/logging/middleware/_exclusions.py
+++ b/src/i_dot_ai_utilities/logging/middleware/_exclusions.py
@@ -1,0 +1,68 @@
+"""Path-exclusion matcher for the Django logging middleware.
+
+Supports two match modes:
+
+- Prefix matching (default): O(n) string comparisons, predictable, no regex.
+- Regex matching (opt-in): compiled once at construction time.
+
+Prefix defaults are health-check endpoints we observed across i.AI services.
+Pure Python: no Django import.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, Final
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+
+# Health-check prefixes that all i.AI services should exclude by default.
+# Consumers may override entirely via the ``I_DOT_AI_LOGGING_EXCLUDED_PREFIXES``
+# setting; these are only the defaults.
+DEFAULT_EXCLUDED_PREFIXES: Final[tuple[str, ...]] = (
+    "/health/",
+    "/healthz",
+    "/api/health/",
+    "/api/health/live",
+    "/api/health/ready",
+)
+
+
+class ExclusionMatcher:
+    """Test paths against prefix / regex exclusions.
+
+    Prefixes use a plain ``str.startswith`` check (cheap, deterministic).
+    Regex patterns are accepted either as strings (compiled once in
+    ``__init__``) or as already-compiled ``re.Pattern`` objects (passed through
+    by identity). A match by either mechanism is a full exclusion.
+    """
+
+    __slots__ = ("_prefixes", "_regexes")
+
+    def __init__(
+        self,
+        prefixes: Iterable[str] = (),
+        regexes: Iterable[str | re.Pattern[str]] = (),
+    ) -> None:
+        self._prefixes: tuple[str, ...] = tuple(prefixes)
+        compiled: list[re.Pattern[str]] = []
+        for pattern in regexes:
+            if isinstance(pattern, re.Pattern):
+                compiled.append(pattern)
+            else:
+                compiled.append(re.compile(pattern))
+        self._regexes: tuple[re.Pattern[str], ...] = tuple(compiled)
+
+    def matches(self, path: str) -> bool:
+        """Return ``True`` iff ``path`` is excluded by prefix or regex."""
+        if not path:
+            return False
+        for prefix in self._prefixes:
+            if path.startswith(prefix):
+                return True
+        return any(regex.search(path) for regex in self._regexes)
+
+    def __repr__(self) -> str:
+        return f"ExclusionMatcher(prefixes={self._prefixes!r}, regexes={[r.pattern for r in self._regexes]!r})"

--- a/src/i_dot_ai_utilities/logging/middleware/_headers.py
+++ b/src/i_dot_ai_utilities/logging/middleware/_headers.py
@@ -34,8 +34,8 @@ X_REQUEST_ID: Final[str] = "X-Request-ID"
 
 
 # Header names the middleware MUST refuse to log even when explicitly named
-# in ``I_DOT_AI_LOGGING_HEADER_ALLOWLIST``. Constitution Art. 52 makes this
-# guarantee unconditional, since a misconfigured allowlist is a plausible
+# in ``I_DOT_AI_LOGGING_HEADER_ALLOWLIST``. This guarantee is
+# unconditional, since a misconfigured allowlist is a plausible
 # operational mistake, and a denylist floor keeps the guarantee intact. Match
 # is case-insensitive.
 FORBIDDEN_HEADER_NAMES: Final[frozenset[str]] = frozenset(
@@ -56,7 +56,7 @@ FORBIDDEN_HEADER_NAMES: Final[frozenset[str]] = frozenset(
 # Envoy UUIDs, CloudFront opaque base64 identifiers, and JWT-shaped tokens.
 # Deliberately restrictive: any character outside this class is rejected to
 # prevent log-injection, log-search hijack, and correlation poisoning via
-# attacker-controlled X-Request-ID values (see security finding A3).
+# attacker-controlled X-Request-ID values.
 _REQUEST_ID_CHARSET_RE = re.compile(r"^[A-Za-z0-9._~=:+/\-]+$")
 
 

--- a/src/i_dot_ai_utilities/logging/middleware/_headers.py
+++ b/src/i_dot_ai_utilities/logging/middleware/_headers.py
@@ -1,0 +1,107 @@
+"""Canonical HTTP header names, size caps, and request-id validation.
+
+Header name constants are in the canonical over-the-wire form (mixed case for
+readability). Django's ``HttpRequest.headers`` lookup is case-insensitive, so
+these values can be passed directly to ``request.headers.get(...)``.
+
+Size caps live in ``i_dot_ai_utilities.logging._limits`` so the middleware
+has a single source of truth; they are re-exported here for backwards
+compatibility.
+
+``validate_request_id`` is kept local to this module (rather than pulled in
+from the deleted ``_trace`` parser) because it is the single validation the
+OTel-backed middleware still needs to perform on inbound correlation headers.
+
+Pure Python module: no third-party imports, no side effects on import.
+"""
+
+import re
+from typing import Final
+
+from i_dot_ai_utilities.logging._limits import (
+    MAX_HEADER_VALUE,
+    MAX_REQUEST_ID,
+    MAX_URL_PATH,
+    MAX_URL_QUERY,
+)
+
+# Per-hop correlation header. Trace propagation (``traceparent`` /
+# ``X-Amzn-Trace-Id``) is handled by the OpenTelemetry composite
+# propagator installed via ``configure_otel_for_django``; the middleware
+# only reads ``X-Request-ID`` directly to preserve an opaque upstream
+# correlation id separately from the OTel span context.
+X_REQUEST_ID: Final[str] = "X-Request-ID"
+
+
+# Header names the middleware MUST refuse to log even when explicitly named
+# in ``I_DOT_AI_LOGGING_HEADER_ALLOWLIST``. Constitution Art. 52 makes this
+# guarantee unconditional, since a misconfigured allowlist is a plausible
+# operational mistake, and a denylist floor keeps the guarantee intact. Match
+# is case-insensitive.
+FORBIDDEN_HEADER_NAMES: Final[frozenset[str]] = frozenset(
+    {
+        "authorization",
+        "cookie",
+        "set-cookie",
+        "proxy-authorization",
+        "x-csrftoken",
+        "x-csrf-token",
+        "www-authenticate",
+        "x-api-key",
+    }
+)
+
+
+# RFC 3986 §2.3 unreserved characters plus the common separators seen in
+# Envoy UUIDs, CloudFront opaque base64 identifiers, and JWT-shaped tokens.
+# Deliberately restrictive: any character outside this class is rejected to
+# prevent log-injection, log-search hijack, and correlation poisoning via
+# attacker-controlled X-Request-ID values (see security finding A3).
+_REQUEST_ID_CHARSET_RE = re.compile(r"^[A-Za-z0-9._~=:+/\-]+$")
+
+
+def validate_request_id(
+    value: str | None,
+    *,
+    max_length: int = MAX_REQUEST_ID,
+) -> str | None:
+    """Validate and truncate an opaque ``X-Request-ID``-style identifier.
+
+    Behaviour:
+
+    - Returns the input stripped and truncated to ``max_length`` if non-empty
+      AND composed entirely of RFC 3986 unreserved characters plus the
+      common ``=``, ``+``, ``/`` separators seen in base64 identifiers.
+    - Returns ``None`` for ``None``, empty, whitespace-only, or non-string
+      values.
+    - Returns ``None`` for values containing characters outside the
+      permitted charset (e.g. whitespace, control bytes, quoting chars).
+    - Never validates as UUID (Envoy uses UUID, CloudFront uses opaque
+      base64, both are valid ``X-Request-ID`` / equivalents).
+    - Never regenerates when present, since upstream correlation depends on the
+      verbatim value being preserved.
+
+    Security (finding A3): accepting attacker-chosen ``X-Request-ID``
+    values verbatim into log context enables log-injection and
+    log-search hijack. The strict charset is the mitigation.
+    """
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    if not stripped:
+        return None
+    truncated = stripped[:max_length]
+    if _REQUEST_ID_CHARSET_RE.match(truncated) is None:
+        return None
+    return truncated
+
+
+__all__ = [
+    "FORBIDDEN_HEADER_NAMES",
+    "MAX_HEADER_VALUE",
+    "MAX_REQUEST_ID",
+    "MAX_URL_PATH",
+    "MAX_URL_QUERY",
+    "X_REQUEST_ID",
+    "validate_request_id",
+]

--- a/src/i_dot_ai_utilities/logging/middleware/_levels.py
+++ b/src/i_dot_ai_utilities/logging/middleware/_levels.py
@@ -1,0 +1,63 @@
+"""Small pure helpers: log-level selection, duration computation, truncation.
+
+Kept in a dedicated module so they can be tested in isolation and reused
+without pulling in any Django code.
+
+``truncate`` has moved to ``i_dot_ai_utilities.logging._limits`` (so the
+enricher can share it without crossing the middleware subpackage boundary).
+It is re-exported here for backwards compatibility.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+from i_dot_ai_utilities.logging._limits import truncate
+
+# Canonical log level names (lowercase to match structlog's conventions).
+LEVEL_INFO: Final[str] = "info"
+LEVEL_WARNING: Final[str] = "warning"
+LEVEL_ERROR: Final[str] = "error"
+
+# HTTP status class boundaries, named so the level selector reads clearly.
+_STATUS_CLIENT_ERROR_MIN: Final[int] = 400
+_STATUS_SERVER_ERROR_MIN: Final[int] = 500
+_STATUS_SERVER_ERROR_MAX_EXCLUSIVE: Final[int] = 600
+
+
+def level_for_status(status_code: int) -> str:
+    """Map an HTTP status code to a log level.
+
+    - 2xx / 3xx -> ``info``
+    - 4xx       -> ``warning``
+    - 5xx       -> ``error``
+    - anything else (unmapped 1xx or nonsense values) -> ``info`` as a safe default
+    """
+    if _STATUS_SERVER_ERROR_MIN <= status_code < _STATUS_SERVER_ERROR_MAX_EXCLUSIVE:
+        return LEVEL_ERROR
+    if _STATUS_CLIENT_ERROR_MIN <= status_code < _STATUS_SERVER_ERROR_MIN:
+        return LEVEL_WARNING
+    return LEVEL_INFO
+
+
+def duration_ms(start_monotonic: float, end_monotonic: float) -> int:
+    """Return an integer millisecond duration from two ``time.monotonic()`` samples.
+
+    ``time.monotonic()`` is guaranteed non-decreasing; if a caller passes the
+    samples in the wrong order we clamp to zero rather than returning a negative
+    duration (which would corrupt downstream aggregations).
+    """
+    delta_ms = (end_monotonic - start_monotonic) * 1000.0
+    if delta_ms < 0:
+        return 0
+    return int(delta_ms)
+
+
+__all__ = [
+    "LEVEL_ERROR",
+    "LEVEL_INFO",
+    "LEVEL_WARNING",
+    "duration_ms",
+    "level_for_status",
+    "truncate",
+]

--- a/src/i_dot_ai_utilities/logging/middleware/_settings.py
+++ b/src/i_dot_ai_utilities/logging/middleware/_settings.py
@@ -1,0 +1,231 @@
+"""Settings names and logger-resolution helper for the Django middleware.
+
+Setting names are namespaced (``I_DOT_AI_LOGGING_...``) so they cannot collide
+with Django's own ``LOGGING`` setting. Django-specific imports are deliberately
+**lazy** (inside ``resolve_logger``) so this module stays importable in
+non-Django consumers, verified by ``test_optional_django_import.py``.
+
+Security note (finding A4): ``I_DOT_AI_LOGGER`` deliberately does NOT accept
+dotted-import strings. A string-based configuration value would let anyone
+who can influence Django settings (env var, settings override, Helm values)
+trigger ``import_string`` and ``__call__`` arbitrary modules during
+middleware boot, executing attacker code before any view or auth check.
+Consumers must pass a fully-constructed logger object or a zero-arg
+callable imported in their own ``settings.py``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Final, Protocol, runtime_checkable
+
+# --- Setting-name constants -------------------------------------------------
+
+SETTING_LOGGER: Final[str] = "I_DOT_AI_LOGGER"
+SETTING_ENABLED: Final[str] = "I_DOT_AI_LOGGING_MIDDLEWARE_ENABLED"
+SETTING_EXCLUDED_PREFIXES: Final[str] = "I_DOT_AI_LOGGING_EXCLUDED_PREFIXES"
+SETTING_EXCLUDED_REGEXES: Final[str] = "I_DOT_AI_LOGGING_EXCLUDED_REGEXES"
+SETTING_HEADER_ALLOWLIST: Final[str] = "I_DOT_AI_LOGGING_HEADER_ALLOWLIST"
+
+
+# --- Logger resolution ------------------------------------------------------
+
+
+@runtime_checkable
+class _StructuredLoggerLike(Protocol):
+    """Minimal duck-typed shape for an acceptable logger object.
+
+    The library's own ``StructuredLogger`` satisfies this, but so does anything
+    else that exposes the five method names used by the middleware. Kept as a
+    ``runtime_checkable`` Protocol so we can validate user-supplied objects
+    cleanly.
+
+    ``refresh_context`` accepts an optional ``scope`` keyword introduced
+    alongside the request-scope ownership check in ``StructuredLogger``.
+    Custom loggers may ignore it. The middleware always passes it by keyword
+    so positional-only implementations continue to work.
+    """
+
+    def info(self, message_template: str, **kwargs: Any) -> None: ...
+    def warning(self, message_template: str, **kwargs: Any) -> None: ...
+    def error(self, message_template: str, **kwargs: Any) -> None: ...
+    def exception(self, message_template: str, **kwargs: Any) -> None: ...
+    def refresh_context(
+        self,
+        context_enrichers: Any | None = None,
+        scope: str = "manual",
+    ) -> None: ...
+    def set_context_field(self, field_key: str, field_value: Any) -> None: ...
+
+
+class _BareStructlogAdapter:
+    """Adapter that surfaces the five-method contract over a plain structlog
+    bound logger.
+
+    The middleware's default path (no ``I_DOT_AI_LOGGER`` configured) returns
+    ``structlog.get_logger(__name__)``. That object exposes
+    ``info``/``warning``/``error``/``exception`` but not ``refresh_context``
+    / ``set_context_field`` (the latter are library-specific conveniences).
+    Wrapping keeps the middleware's call sites uniform and honours Art. 22
+    by never calling ``structlog.configure``.
+
+    ``refresh_context`` clears ``structlog.contextvars`` and invokes any
+    supplied enrichers directly through ``EnrichmentProvider``. That matches
+    what ``StructuredLogger.refresh_context`` does for non-owned scopes. The
+    ``scope`` argument is accepted for interface parity; there is no
+    per-request ownership registry in the bare-logger path (consumers wanting
+    ownership enforcement should pass ``StructuredLogger``).
+    """
+
+    __slots__ = ("_logger", "_provider")
+
+    def __init__(self, logger: Any) -> None:
+        self._logger = logger
+        # The provider is lazily created on first ``refresh_context`` call so
+        # importing this module cannot pull in enricher-side code paths that
+        # should only run at request time.
+        self._provider: Any = None
+
+    def info(self, message_template: str, **kwargs: Any) -> None:
+        self._logger.info(message_template, **kwargs)
+
+    def warning(self, message_template: str, **kwargs: Any) -> None:
+        self._logger.warning(message_template, **kwargs)
+
+    def error(self, message_template: str, **kwargs: Any) -> None:
+        self._logger.error(message_template, **kwargs)
+
+    def exception(self, message_template: str, **kwargs: Any) -> None:
+        self._logger.exception(message_template, **kwargs)
+
+    def set_context_field(self, field_key: str, field_value: Any) -> None:
+        import structlog  # noqa: PLC0415
+
+        structlog.contextvars.bind_contextvars(**{field_key: field_value})
+
+    def refresh_context(
+        self,
+        context_enrichers: Any | None = None,
+        scope: str = "manual",  # noqa: ARG002 - parity with StructuredLogger
+    ) -> None:
+        import structlog  # noqa: PLC0415
+
+        structlog.contextvars.clear_contextvars()
+        if not context_enrichers:
+            return
+
+        # Lazy-build the provider so non-Django consumers don't pay for it.
+        if self._provider is None:
+            from i_dot_ai_utilities.logging.enrichers.enrichment_provider import (  # noqa: PLC0415
+                EnrichmentProvider,
+            )
+            from i_dot_ai_utilities.logging.types.enrichment_types import (  # noqa: PLC0415
+                ExecutionEnvironmentType,
+            )
+
+            self._provider = EnrichmentProvider(ExecutionEnvironmentType.LOCAL)
+
+        combined: dict[str, Any] = {}
+        for spec in context_enrichers:
+            enricher_type = spec.get("type") if isinstance(spec, dict) else None
+            target = spec.get("object") if isinstance(spec, dict) else None
+            if enricher_type is None or target is None:
+                continue
+            extracted = self._provider.extract_context_from_framework_enricher(self._logger, enricher_type, target)
+            if extracted:
+                combined.update(extracted)
+        if combined:
+            structlog.contextvars.bind_contextvars(**combined)
+
+
+def _default_logger() -> Any:
+    """Fallback logger when no setting is provided.
+
+    Returns a ``_BareStructlogAdapter`` over ``structlog.get_logger(__name__)``.
+    This deliberately does NOT instantiate the library's ``StructuredLogger`` since
+    the latter's ``__init__`` calls
+    ``ProcessorHelper().configure_processors(...)``, which globally mutates
+    ``structlog`` configuration. The middleware is forbidden from calling
+    ``structlog.configure()`` (constitution Art. 22), so the default path must
+    not trigger it transitively either. Consumers who want the full
+    ``StructuredLogger`` experience should construct one in their own
+    ``settings.py`` and pass it via ``I_DOT_AI_LOGGER``.
+    """
+    import structlog  # noqa: PLC0415
+
+    return _BareStructlogAdapter(structlog.get_logger(__name__))
+
+
+def _call_callable(
+    raw: Any,
+    label: str,
+) -> Any:
+    """Invoke a zero-arg callable, raising ``ImproperlyConfigured`` on failure.
+
+    Factored out so ``resolve_logger`` stays simple and the exception-to-
+    ImproperlyConfigured adaptation is applied consistently.
+    """
+    from django.core.exceptions import ImproperlyConfigured  # type: ignore[import-untyped]  # noqa: PLC0415
+
+    try:
+        produced = raw()
+    except Exception as exc:
+        msg = f"i_dot_ai_utilities logging: {label} raised {type(exc).__name__}: {exc}."
+        raise ImproperlyConfigured(msg) from exc
+    if isinstance(produced, _StructuredLoggerLike):
+        return produced
+    msg = (
+        f"i_dot_ai_utilities logging: {label} returned "
+        f"{type(produced).__name__!s}, which is not a structured logger "
+        f"(must expose info/warning/error/exception/refresh_context)."
+    )
+    raise ImproperlyConfigured(msg)
+
+
+def resolve_logger(raw: Any) -> Any:
+    """Resolve a user-supplied ``I_DOT_AI_LOGGER`` setting into a logger object.
+
+    Accepts any of:
+
+    - ``None`` / absent: returns a default ``StructuredLogger`` instance.
+    - Zero-arg callable: invoked, result validated.
+    - Any object that quacks like a structured logger: returned as-is.
+
+    **Does NOT accept dotted-import strings.** Security finding A4: a string
+    configuration value would give anyone able to influence Django settings
+    (env var, settings override, Helm values, shared config) the ability to
+    import arbitrary Python modules and invoke their zero-arg callables
+    during middleware boot, effectively code-execution-at-init. Consumers
+    must import their logger in their own ``settings.py`` and assign the
+    object/callable directly.
+
+    Raises ``django.core.exceptions.ImproperlyConfigured`` on malformed input.
+    Django imports are performed lazily inside this function so the module
+    stays importable for non-Django consumers.
+    """
+    if raw is None:
+        return _default_logger()
+
+    from django.core.exceptions import ImproperlyConfigured  # type: ignore[import-untyped]  # noqa: PLC0415
+
+    if isinstance(raw, str):
+        # Security (finding A4): strings are forbidden. Produce a clear
+        # message so operators understand why and how to migrate.
+        msg = (
+            f"i_dot_ai_utilities logging: {SETTING_LOGGER} no longer accepts "
+            f"a dotted-import string. Pass a fully-constructed logger object "
+            f"or a zero-arg callable imported in your settings.py. This "
+            f"closes a boot-time arbitrary-import attack surface "
+            f"(see release notes for 0.6.0)."
+        )
+        raise ImproperlyConfigured(msg)
+
+    if isinstance(raw, _StructuredLoggerLike):
+        return raw
+
+    if callable(raw):
+        return _call_callable(raw, label=f"{SETTING_LOGGER} callable")
+
+    msg = (
+        f"i_dot_ai_utilities logging: {SETTING_LOGGER} must be a callable or a logger object. Got {type(raw).__name__}."
+    )
+    raise ImproperlyConfigured(msg)

--- a/src/i_dot_ai_utilities/logging/middleware/_settings.py
+++ b/src/i_dot_ai_utilities/logging/middleware/_settings.py
@@ -65,8 +65,8 @@ class _BareStructlogAdapter:
     ``structlog.get_logger(__name__)``. That object exposes
     ``info``/``warning``/``error``/``exception`` but not ``refresh_context``
     / ``set_context_field`` (the latter are library-specific conveniences).
-    Wrapping keeps the middleware's call sites uniform and honours Art. 22
-    by never calling ``structlog.configure``.
+    Wrapping keeps the middleware's call sites uniform, and never
+    calls ``structlog.configure``.
 
     ``refresh_context`` clears ``structlog.contextvars`` and invokes any
     supplied enrichers directly through ``EnrichmentProvider``. That matches
@@ -145,7 +145,7 @@ def _default_logger() -> Any:
     the latter's ``__init__`` calls
     ``ProcessorHelper().configure_processors(...)``, which globally mutates
     ``structlog`` configuration. The middleware is forbidden from calling
-    ``structlog.configure()`` (constitution Art. 22), so the default path must
+    ``structlog.configure()``, so the default path must
     not trigger it transitively either. Consumers who want the full
     ``StructuredLogger`` experience should construct one in their own
     ``settings.py`` and pass it via ``I_DOT_AI_LOGGER``.

--- a/src/i_dot_ai_utilities/logging/middleware/django_otel.py
+++ b/src/i_dot_ai_utilities/logging/middleware/django_otel.py
@@ -151,7 +151,7 @@ class StructuredLoggingMiddlewareOTel:
         raw_allowlist = getattr(settings, SETTING_HEADER_ALLOWLIST, ())
         self._header_allowlist, rejected = self._normalise_header_allowlist(raw_allowlist)
 
-        # (Art. 6, 51) One startup line so operators can see the middleware
+        # One startup line so operators can see the middleware
         # is active; bind the schema version so the version is on the event
         # regardless of whether the consumer also inspects per-request logs.
         # A broken logger must not crash the worker; fall back to stderr so
@@ -175,7 +175,7 @@ class StructuredLoggingMiddlewareOTel:
         regexes_raw: object,
     ) -> ExclusionMatcher:
         """Construct the path-exclusion matcher, mapping malformed input
-        to ``ImproperlyConfigured`` (Art. 15).
+        to ``ImproperlyConfigured``.
         """
         # A bare str/bytes is iterable, so ExclusionMatcher would silently
         # treat "/health/" as five single-character prefixes instead of one.
@@ -207,7 +207,7 @@ class StructuredLoggingMiddlewareOTel:
     def _normalise_header_allowlist(
         raw_allowlist: object,
     ) -> tuple[tuple[str, ...], list[str]]:
-        """Apply the denylist floor to the header allowlist (Art. 52, 53).
+        """Apply the denylist floor to the header allowlist.
 
         Returns ``(filtered_allowlist, rejected_names)``. Non-string entries
         are dropped silently (copy-paste bugs shouldn't brick startup).
@@ -324,7 +324,7 @@ class StructuredLoggingMiddlewareOTel:
             )
 
     def __call__(self, request: HttpRequest) -> HttpResponse:
-        # (Art. 21) Clear ``structlog.contextvars`` FIRST, before header
+        # Clear ``structlog.contextvars`` FIRST, before header
         # parsing, before the timer starts, before anything that could
         # raise. Protects against residual context leaking from a prior
         # request on the same Gunicorn sync-worker thread. The clear
@@ -351,17 +351,17 @@ class StructuredLoggingMiddlewareOTel:
         # mid-request.
         scope_token = _claim_request_scope(REQUEST_SCOPE_OWNER_MIDDLEWARE)
         try:
-            # (Art. 51) Bind the schema version as soon as ownership is
+            # Bind the schema version as soon as ownership is
             # established so it appears on every event emitted during
             # this request.
             self._logger.set_context_field("logging_schema_version", _SCHEMA_VERSION)
 
-            # (Art. 48) Exclusions: skip logging entirely. Still call
+            # Exclusions: skip logging entirely. Still call
             # through to the view so health probes work.
             if self._exclusions.matches(request.path):
                 return self._get_response(request)
 
-            # (Art. 30, 32) Per-hop correlation id.
+            # Per-hop correlation id.
             # - ``request_id`` is ALWAYS a freshly generated UUID4 hex
             #   (distinct from trace_id, which comes from the OTel span).
             # - Any valid inbound ``X-Request-ID`` is preserved verbatim
@@ -369,12 +369,12 @@ class StructuredLoggingMiddlewareOTel:
             #   inbound values produce no ``upstream_request_id`` field.
             self._bind_request_ids(request)
 
-            # (Art. 53, 54) Allowlisted header capture. Denylist floor is
+            # Allowlisted header capture. Denylist floor is
             # enforced at ``__init__`` time; header values are length-
             # capped here.
             self._bind_allowlisted_headers(request)
 
-            # (Art. 37) Start the timer AFTER refresh_context so context-
+            # Start the timer AFTER refresh_context so context-
             # setup cost is not counted, but before we log
             # ``request_started`` so the two log events bracket the same
             # interval.
@@ -382,7 +382,7 @@ class StructuredLoggingMiddlewareOTel:
 
             self._logger.info(_EVENT_STARTED)
 
-            # (Art. 40, 47) ``try`` / ``except`` / ``finally`` with an
+            # ``try`` / ``except`` / ``finally`` with an
             # idempotency guard: the completion event is emitted from
             # ``finally`` when the exception branches did not already log
             # their own event, so every non-excluded request produces
@@ -395,7 +395,7 @@ class StructuredLoggingMiddlewareOTel:
                 response = self._get_response(request)
                 status_code = getattr(response, "status_code", _STATUS_SYNTH_ON_EXCEPTION)
             except Http404 as exc:
-                # (Art. 46) 404 is ordinary traffic; log at WARNING, never
+                # 404 is ordinary traffic; log at WARNING, never
                 # ERROR, and synthesise status 404 rather than the generic
                 # 500. ``error.type`` uses the status code string per OTel
                 # HTTP server semconv guidance.
@@ -403,7 +403,7 @@ class StructuredLoggingMiddlewareOTel:
                 emitted = True
                 raise
             except Exception as exc:
-                # (Art. 40-44) Log inside the ``except`` block so
+                # Log inside the ``except`` block so
                 # ``sys.exc_info`` captures the traceback. Synthesise
                 # status 500, bind OTel-aligned ``error.type`` (FQN), then
                 # re-raise with bare ``raise`` to preserve the traceback
@@ -421,7 +421,7 @@ class StructuredLoggingMiddlewareOTel:
                     assert response is not None  # for type narrowing  # noqa: S101
                     self._emit_completed(start, status_code)
 
-            # (Art. 3) Return the response object unchanged.
+            # Return the response object unchanged.
             return response
         finally:
             _release_request_scope(scope_token)
@@ -458,7 +458,7 @@ class StructuredLoggingMiddlewareOTel:
         elapsed = duration_ms(start, time.monotonic())
         self._logger.set_context_field("http.response.status_code", status_code)
         self._logger.set_context_field("duration_ms", elapsed)
-        # (Art. 50 + OTel) ``error.type`` for non-2xx/3xx responses. Uses
+        # ``error.type`` for non-2xx/3xx responses. Uses
         # the HTTP status code string per the HTTP semconv note 4.
         if status_code >= _STATUS_ERROR_THRESHOLD:
             self._logger.set_context_field("error.type", str(status_code))
@@ -469,8 +469,7 @@ class StructuredLoggingMiddlewareOTel:
     def _emit_http404(self, start: float, exc: Http404) -> None:
         """Log ``Http404`` at WARNING with synthetic status 404.
 
-        Constitution Art. 46: ``Http404`` MUST be logged at INFO or WARNING,
-        never ERROR. We pick WARNING so it mirrors the normal
+        ``Http404`` is logged at WARNING, never ERROR, so it mirrors the normal
         ``level_for_status(404)`` result and consumers see a single rule:
         "4xx → warning". Emits ``request_completed`` (not ``request_failed``)
         because a 404 is an ordinary outcome, not a server-side failure.
@@ -489,13 +488,13 @@ class StructuredLoggingMiddlewareOTel:
         """Log an unhandled exception at ERROR and synthesise status 500.
 
         Must be called from inside the ``except`` block so ``logger.exception``
-        picks up ``sys.exc_info`` correctly (Art. 42).
+        picks up ``sys.exc_info`` correctly.
         """
         elapsed = duration_ms(start, time.monotonic())
         self._logger.set_context_field("exception.type", type(exc).__name__)
         self._logger.set_context_field("http.response.status_code", _STATUS_SYNTH_ON_EXCEPTION)
         self._logger.set_context_field("duration_ms", elapsed)
-        # (Art. 50 + OTel) ``error.type`` on the exception path uses the
+        # ``error.type`` on the exception path uses the
         # fully-qualified class name per HTTP server semconv note 4
         # ("exception type (its fully-qualified class name, if applicable)").
         cls = type(exc)
@@ -508,11 +507,11 @@ class StructuredLoggingMiddlewareOTel:
     def _bind_request_ids(self, request: HttpRequest) -> None:
         """Bind ``request_id`` (always fresh) and optional ``upstream_request_id``.
 
-        Constitution Art. 32: ``request_id`` MUST be a fresh per-hop UUID4,
-        distinct from any inbound correlation value. Art. 30: inbound
-        ``X-Request-ID`` is accepted verbatim, length-capped, and charset-
-        restricted (security finding A3, block log-injection / log-search
-        hijack via attacker-chosen identifiers). When validation rejects an
+        ``request_id`` is always a fresh per-hop UUID4, distinct from any
+        inbound correlation value. Inbound ``X-Request-ID`` is accepted
+        verbatim, length-capped, and charset-restricted to block
+        log-injection / log-search hijack via attacker-chosen identifiers.
+        When validation rejects an
         inbound value, ``upstream_request_id`` is simply omitted; the
         locally-minted ``request_id`` is unaffected.
         """

--- a/src/i_dot_ai_utilities/logging/middleware/django_otel.py
+++ b/src/i_dot_ai_utilities/logging/middleware/django_otel.py
@@ -1,0 +1,547 @@
+"""Django ``StructuredLoggingMiddlewareOTel``: the library's Django middleware.
+
+Delegates HTTP-context extraction to OpenTelemetry's Django
+auto-instrumentation: ``DjangoInstrumentor`` creates a server span per
+request whose attributes carry ``http.request.method``, ``url.path``,
+``http.route``, ``http.response.status_code`` etc.
+
+The middleware keeps only the *log-lifecycle* concerns that cannot live
+on a span:
+
+- ``request_started`` / ``request_completed`` / ``request_failed`` events.
+- ``duration_ms`` timing.
+- Status-driven log-level selection (2xx→info, 4xx→warning, 5xx→error).
+- ``request_id`` per-hop correlation (always a fresh UUID4 hex;
+  verbatim inbound ``X-Request-ID`` is preserved separately as
+  ``upstream_request_id`` when present and charset-valid).
+- Exclusions (prefixes + regexes): log-pipeline concern, not span concern.
+- Header allowlist capture: log-pipeline concern, not span concern.
+- ``exception.type`` / ``error.type`` on failures.
+- ``Http404`` carve-out (WARNING + synthetic 404, never ERROR).
+- Scope-ownership guard around ``refresh_context`` so a view calling
+  ``logger.refresh_context()`` cannot silently de-correlate its own
+  audit trail mid-request.
+
+Trace correlation on log records comes from the
+:func:`otel_trace_context_processor` structlog processor reading the
+active span on every event, **not** from the middleware. Consumers MUST
+call :func:`configure_otel_for_django` (or wire the processor into their
+own structlog chain) for ``trace_id`` / ``span_id`` / ``trace_flags`` to
+appear on log lines. The middleware emits a loud one-shot WARNING at
+startup when it detects that no SDK ``TracerProvider`` has been
+installed, so forgetting the setup step is visible immediately rather
+than showing up as a silent absence of trace correlation.
+
+``user.id`` is **not** extracted by this middleware. Consumers who need
+authenticated-user attribution on log records should add
+:class:`i_dot_ai_utilities.logging.middleware.django_user_id.DjangoUserIdMiddleware`
+to ``settings.MIDDLEWARE`` after ``AuthenticationMiddleware`` and this
+middleware. That middleware preserves the hardening (no DB query on
+unhydrated ``SimpleLazyObject``, database-error WARNINGs) without
+reintroducing HTTP-context extraction.
+
+Sync-only, thread-safe under Gunicorn sync / gthread workers via
+``structlog.contextvars``.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+import time
+import uuid
+from typing import TYPE_CHECKING, ClassVar, Final
+
+import structlog
+from django.conf import settings  # type: ignore[import-untyped]
+from django.core.exceptions import (  # type: ignore[import-untyped]
+    ImproperlyConfigured,
+    MiddlewareNotUsed,
+)
+from django.http import Http404  # type: ignore[import-untyped]
+
+from i_dot_ai_utilities.logging.middleware._exclusions import (
+    DEFAULT_EXCLUDED_PREFIXES,
+    ExclusionMatcher,
+)
+from i_dot_ai_utilities.logging.middleware._headers import (
+    FORBIDDEN_HEADER_NAMES,
+    MAX_HEADER_VALUE,
+    X_REQUEST_ID,
+    validate_request_id,
+)
+from i_dot_ai_utilities.logging.middleware._levels import (
+    LEVEL_ERROR,
+    LEVEL_WARNING,
+    duration_ms,
+    level_for_status,
+    truncate,
+)
+from i_dot_ai_utilities.logging.middleware._settings import (
+    SETTING_ENABLED,
+    SETTING_EXCLUDED_PREFIXES,
+    SETTING_EXCLUDED_REGEXES,
+    SETTING_HEADER_ALLOWLIST,
+    SETTING_LOGGER,
+    resolve_logger,
+)
+from i_dot_ai_utilities.logging.structured_logger import (
+    REQUEST_SCOPE_OWNER_MIDDLEWARE,
+    _claim_request_scope,
+    _release_request_scope,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from django.http import HttpRequest, HttpResponse  # type: ignore[import-untyped]
+
+
+# Event names kept as module constants so renaming is a single-file change.
+_EVENT_STARTED = "request_started"
+_EVENT_COMPLETED = "request_completed"
+_EVENT_FAILED = "request_failed"
+_EVENT_STARTUP = "structured_logging_middleware_otel_active"
+_EVENT_FORBIDDEN_HEADERS_REJECTED = "structured_logging_middleware_otel_forbidden_headers_rejected"
+_EVENT_TRACER_PROVIDER_MISSING = "structured_logging_middleware_otel_tracer_provider_missing"
+
+# Synthesised statuses when a view raises.
+_STATUS_SYNTH_ON_EXCEPTION: Final[int] = 500
+_STATUS_NOT_FOUND: Final[int] = 404
+
+# HTTP error threshold. 4xx/5xx responses carry ``error.type`` per OTel
+# HTTP server semconv note 4 ("if status indicates an error... set to the
+# status code number (represented as a string)").
+_STATUS_ERROR_THRESHOLD: Final[int] = 400
+
+# Schema version, bound onto every log event emitted by this middleware so
+# downstream consumers can detect breaking changes without grepping source.
+# Distinct from the original middleware's schema; start at 1.0 for the
+# narrower OTel-backed log shape.
+_SCHEMA_VERSION: Final[str] = "1.0"
+
+
+class StructuredLoggingMiddlewareOTel:
+    """Per-request structured-logging middleware for Django, OTel edition.
+
+    Sync-only. Place high in ``MIDDLEWARE`` (after ``SecurityMiddleware``
+    and ``AuthenticationMiddleware``; before view-level middleware) so
+    the timer and lifecycle logs wrap the full request/response cycle.
+    Django auto-instrumentation is configured at process startup via
+    :func:`configure_otel_for_django`, independent of middleware ordering.
+    """
+
+    sync_capable: ClassVar[bool] = True
+    async_capable: ClassVar[bool] = False
+
+    def __init__(self, get_response: Callable[[HttpRequest], HttpResponse]) -> None:
+        self._get_response = get_response
+
+        enabled = getattr(settings, SETTING_ENABLED, True)
+        if not enabled:
+            msg = "StructuredLoggingMiddlewareOTel disabled via settings."
+            raise MiddlewareNotUsed(msg)
+
+        self._logger = resolve_logger(getattr(settings, SETTING_LOGGER, None))
+
+        prefixes_raw = getattr(settings, SETTING_EXCLUDED_PREFIXES, DEFAULT_EXCLUDED_PREFIXES)
+        regexes_raw = getattr(settings, SETTING_EXCLUDED_REGEXES, ())
+        self._exclusions = self._build_exclusions(prefixes_raw, regexes_raw)
+
+        raw_allowlist = getattr(settings, SETTING_HEADER_ALLOWLIST, ())
+        self._header_allowlist, rejected = self._normalise_header_allowlist(raw_allowlist)
+
+        # (Art. 6, 51) One startup line so operators can see the middleware
+        # is active; bind the schema version so the version is on the event
+        # regardless of whether the consumer also inspects per-request logs.
+        # A broken logger must not crash the worker; fall back to stderr so
+        # the problem remains visible.
+        self._emit_startup_log(prefixes_raw, regexes_raw)
+
+        if rejected:
+            self._emit_forbidden_headers_warning(rejected)
+
+        # Loudly complain if the caller has not wired OpenTelemetry up at
+        # process startup. Without a real SDK TracerProvider no spans are
+        # produced and the ``otel_trace_context_processor`` has nothing to
+        # inject. The middleware still works but trace correlation is
+        # silently absent. The warning names the remediation so operators
+        # don't have to grep docs to recover.
+        self._warn_if_tracer_provider_missing()
+
+    @staticmethod
+    def _build_exclusions(
+        prefixes_raw: object,
+        regexes_raw: object,
+    ) -> ExclusionMatcher:
+        """Construct the path-exclusion matcher, mapping malformed input
+        to ``ImproperlyConfigured`` (Art. 15).
+        """
+        # A bare str/bytes is iterable, so ExclusionMatcher would silently
+        # treat "/health/" as five single-character prefixes instead of one.
+        # Reject it up front rather than exclude half the site by accident.
+        for value, name in ((prefixes_raw, SETTING_EXCLUDED_PREFIXES), (regexes_raw, SETTING_EXCLUDED_REGEXES)):
+            if isinstance(value, str | bytes):
+                msg = (
+                    f"i_dot_ai_utilities logging: {name} must be an iterable of "
+                    f"strings, not a bare string; wrap it in a list/tuple."
+                )
+                raise ImproperlyConfigured(msg)
+        try:
+            return ExclusionMatcher(
+                prefixes=prefixes_raw,  # type: ignore[arg-type]
+                regexes=regexes_raw,  # type: ignore[arg-type]
+            )
+        except TypeError as exc:
+            msg = (
+                f"i_dot_ai_utilities logging: {SETTING_EXCLUDED_PREFIXES} / "
+                f"{SETTING_EXCLUDED_REGEXES} must be iterables of strings; "
+                f"got {type(exc).__name__}: {exc}."
+            )
+            raise ImproperlyConfigured(msg) from exc
+        except re.error as exc:
+            msg = f"i_dot_ai_utilities logging: {SETTING_EXCLUDED_REGEXES} contains an invalid regex: {exc}."
+            raise ImproperlyConfigured(msg) from exc
+
+    @staticmethod
+    def _normalise_header_allowlist(
+        raw_allowlist: object,
+    ) -> tuple[tuple[str, ...], list[str]]:
+        """Apply the denylist floor to the header allowlist (Art. 52, 53).
+
+        Returns ``(filtered_allowlist, rejected_names)``. Non-string entries
+        are dropped silently (copy-paste bugs shouldn't brick startup).
+        Malformed (non-iterable) settings raise ``ImproperlyConfigured``.
+        """
+        # A bare str/bytes is iterable, so it would silently become a
+        # per-character allowlist. Reject it rather than build a useless one.
+        if isinstance(raw_allowlist, str | bytes):
+            msg = (
+                f"i_dot_ai_utilities logging: {SETTING_HEADER_ALLOWLIST} must be "
+                f"an iterable of strings, not a bare string; wrap it in a list/tuple."
+            )
+            raise ImproperlyConfigured(msg)
+        try:
+            allowlist_iter = list(raw_allowlist)  # type: ignore[call-overload]
+        except TypeError as exc:
+            msg = (
+                f"i_dot_ai_utilities logging: {SETTING_HEADER_ALLOWLIST} "
+                f"must be an iterable of strings; got "
+                f"{type(raw_allowlist).__name__}."
+            )
+            raise ImproperlyConfigured(msg) from exc
+
+        filtered: list[str] = []
+        rejected: list[str] = []
+        for name in allowlist_iter:
+            if not isinstance(name, str):
+                continue
+            if name.lower() in FORBIDDEN_HEADER_NAMES:
+                rejected.append(name)
+            else:
+                filtered.append(name)
+        return tuple(filtered), rejected
+
+    def _emit_startup_log(
+        self,
+        prefixes_raw: object,
+        regexes_raw: object,
+    ) -> None:
+        try:
+            self._logger.info(
+                _EVENT_STARTUP,
+                logger=type(self._logger).__name__,
+                excluded_prefixes=list(prefixes_raw),  # type: ignore[call-overload]
+                excluded_regex_count=len(tuple(regexes_raw)),  # type: ignore[arg-type]
+                header_allowlist_size=len(self._header_allowlist),
+                logging_schema_version=_SCHEMA_VERSION,
+            )
+        except Exception as exc:  # noqa: BLE001 - last-resort observability
+            print(  # noqa: T201
+                f"i_dot_ai_utilities: startup log emission failed: {type(exc).__name__}: {exc}",
+                file=sys.stderr,
+            )
+
+    def _emit_forbidden_headers_warning(self, rejected: list[str]) -> None:
+        try:
+            self._logger.warning(
+                _EVENT_FORBIDDEN_HEADERS_REJECTED,
+                rejected=list(rejected),
+                logging_schema_version=_SCHEMA_VERSION,
+            )
+        except Exception as exc:  # noqa: BLE001 - last-resort observability
+            print(  # noqa: T201
+                f"i_dot_ai_utilities: forbidden-header warning failed: {type(exc).__name__}: {exc}",
+                file=sys.stderr,
+            )
+
+    def _warn_if_tracer_provider_missing(self) -> None:
+        """Emit a one-shot WARNING if no SDK ``TracerProvider`` is installed.
+
+        OpenTelemetry's API exposes a default ``ProxyTracerProvider`` when
+        no real provider has been registered. Any spans the middleware
+        relies on (and any ``trace_id`` / ``span_id`` the structlog
+        processor would otherwise inject) are no-ops in that state.
+
+        We check for a genuine SDK provider by isinstance rather than
+        identity so subclasses (including test providers and vendor
+        providers) are all accepted. A mis-configured process therefore
+        gets one loud, named event at worker startup pointing operators
+        straight at ``configure_otel_for_django`` as the fix. The check
+        is tolerant: anything unexpected during the probe (including
+        import errors in exotic test environments) is swallowed so
+        middleware init never fails because of observability scaffolding.
+        """
+        try:
+            from opentelemetry import trace  # noqa: PLC0415
+            from opentelemetry.sdk.trace import TracerProvider  # noqa: PLC0415
+
+            provider = trace.get_tracer_provider()
+            if isinstance(provider, TracerProvider):
+                return
+
+            try:
+                self._logger.warning(
+                    _EVENT_TRACER_PROVIDER_MISSING,
+                    actual_provider=type(provider).__name__,
+                    logging_schema_version=_SCHEMA_VERSION,
+                    remediation=(
+                        "call i_dot_ai_utilities.logging._otel."
+                        "configure_otel_for_django(service_name=...) at "
+                        "process startup (wsgi.py / asgi.py / "
+                        "AppConfig.ready())"
+                    ),
+                )
+            except Exception as exc:  # noqa: BLE001 - last-resort observability
+                print(  # noqa: T201
+                    (f"i_dot_ai_utilities: tracer-provider-missing warning failed: {type(exc).__name__}: {exc}"),
+                    file=sys.stderr,
+                )
+        except Exception as exc:  # noqa: BLE001 - probe must never crash init
+            print(  # noqa: T201
+                (f"i_dot_ai_utilities: tracer-provider probe failed: {type(exc).__name__}: {exc}"),
+                file=sys.stderr,
+            )
+
+    def __call__(self, request: HttpRequest) -> HttpResponse:
+        # (Art. 21) Clear ``structlog.contextvars`` FIRST, before header
+        # parsing, before the timer starts, before anything that could
+        # raise. Protects against residual context leaking from a prior
+        # request on the same Gunicorn sync-worker thread. The clear
+        # lives here (not inside ``refresh_context``) because we're about
+        # to claim request-scope ownership below, and the ownership
+        # guard would otherwise refuse to clear mid-call.
+        structlog.contextvars.clear_contextvars()
+
+        # Rebuild the log context BEFORE claiming request-scope ownership.
+        # If we claimed ownership first, the guard in
+        # ``StructuredLogger.refresh_context`` would treat our own
+        # initiating call as a re-entrant intrusion and emit a spurious
+        # warning on every request. No enricher is passed since HTTP context
+        # lives on the OTel span created by ``DjangoInstrumentor``; the
+        # log record carries only the request_id + lifecycle fields
+        # bound below, plus whatever the trace-context processor injects
+        # on each event.
+        self._logger.refresh_context(scope="request")
+
+        # Now claim request-scope ownership for the duration of this
+        # request. Manual ``refresh_context()`` calls from views or helpers
+        # inside this window will be downgraded to "apply enrichers without
+        # clearing" so audit-trail correlation cannot be silently broken
+        # mid-request.
+        scope_token = _claim_request_scope(REQUEST_SCOPE_OWNER_MIDDLEWARE)
+        try:
+            # (Art. 51) Bind the schema version as soon as ownership is
+            # established so it appears on every event emitted during
+            # this request.
+            self._logger.set_context_field("logging_schema_version", _SCHEMA_VERSION)
+
+            # (Art. 48) Exclusions: skip logging entirely. Still call
+            # through to the view so health probes work.
+            if self._exclusions.matches(request.path):
+                return self._get_response(request)
+
+            # (Art. 30, 32) Per-hop correlation id.
+            # - ``request_id`` is ALWAYS a freshly generated UUID4 hex
+            #   (distinct from trace_id, which comes from the OTel span).
+            # - Any valid inbound ``X-Request-ID`` is preserved verbatim
+            #   as ``upstream_request_id``; charset-invalid or absent
+            #   inbound values produce no ``upstream_request_id`` field.
+            self._bind_request_ids(request)
+
+            # (Art. 53, 54) Allowlisted header capture. Denylist floor is
+            # enforced at ``__init__`` time; header values are length-
+            # capped here.
+            self._bind_allowlisted_headers(request)
+
+            # (Art. 37) Start the timer AFTER refresh_context so context-
+            # setup cost is not counted, but before we log
+            # ``request_started`` so the two log events bracket the same
+            # interval.
+            start = time.monotonic()
+
+            self._logger.info(_EVENT_STARTED)
+
+            # (Art. 40, 47) ``try`` / ``except`` / ``finally`` with an
+            # idempotency guard: the completion event is emitted from
+            # ``finally`` when the exception branches did not already log
+            # their own event, so every non-excluded request produces
+            # exactly one started + one completed-or-failed pair regardless
+            # of control flow.
+            response: HttpResponse | None = None
+            status_code: int | None = None
+            emitted: bool = False
+            try:
+                response = self._get_response(request)
+                status_code = getattr(response, "status_code", _STATUS_SYNTH_ON_EXCEPTION)
+            except Http404 as exc:
+                # (Art. 46) 404 is ordinary traffic; log at WARNING, never
+                # ERROR, and synthesise status 404 rather than the generic
+                # 500. ``error.type`` uses the status code string per OTel
+                # HTTP server semconv guidance.
+                self._emit_http404(start, exc)
+                emitted = True
+                raise
+            except Exception as exc:
+                # (Art. 40-44) Log inside the ``except`` block so
+                # ``sys.exc_info`` captures the traceback. Synthesise
+                # status 500, bind OTel-aligned ``error.type`` (FQN), then
+                # re-raise with bare ``raise`` to preserve the traceback
+                # and keep Django's error handlers functional.
+                self._emit_failed(start, exc)
+                emitted = True
+                raise
+            finally:
+                if not emitted and status_code is not None:
+                    # Success path and 3xx/4xx/5xx responses that did not
+                    # raise: emit exactly one ``request_completed``. We
+                    # use ``finally`` rather than ``else`` so the
+                    # structural guarantee "one event per request" is
+                    # enforced by the control flow, not by convention.
+                    assert response is not None  # for type narrowing  # noqa: S101
+                    self._emit_completed(start, status_code)
+
+            # (Art. 3) Return the response object unchanged.
+            return response
+        finally:
+            _release_request_scope(scope_token)
+
+    def process_exception(
+        self,
+        request: HttpRequest,
+        exception: BaseException,
+    ) -> None:
+        """No-op exception enrichment hook.
+
+        ``__call__``'s ``try/except`` is the source of truth for exception
+        logging. This hook exists purely to satisfy Django's middleware
+        dispatch protocol; returning ``None`` signals "keep looking"
+        without intercepting the exception.
+
+        Security contract (finding A7, matches the original middleware):
+        this method MUST NOT write to structlog's contextvars. Django
+        invokes ``process_exception`` on the way back up the chain before
+        ``__call__``'s ``except`` block runs, and if a later middleware
+        handles the exception and returns a response, any mutations here
+        would bleed into the ``request_completed`` log line AND persist
+        until the next ``refresh_context`` on the same worker thread.
+        Keep this method a true no-op; all enrichment lives in ``__call__``
+        where the scope-ownership guard contains the writes.
+
+        ``request`` and ``exception`` are accepted for signature parity
+        with Django's middleware protocol; intentionally unused.
+        """
+
+    # --- emitters -----------------------------------------------------------
+
+    def _emit_completed(self, start: float, status_code: int) -> None:
+        elapsed = duration_ms(start, time.monotonic())
+        self._logger.set_context_field("http.response.status_code", status_code)
+        self._logger.set_context_field("duration_ms", elapsed)
+        # (Art. 50 + OTel) ``error.type`` for non-2xx/3xx responses. Uses
+        # the HTTP status code string per the HTTP semconv note 4.
+        if status_code >= _STATUS_ERROR_THRESHOLD:
+            self._logger.set_context_field("error.type", str(status_code))
+
+        level = level_for_status(status_code)
+        self._emit(level, _EVENT_COMPLETED)
+
+    def _emit_http404(self, start: float, exc: Http404) -> None:
+        """Log ``Http404`` at WARNING with synthetic status 404.
+
+        Constitution Art. 46: ``Http404`` MUST be logged at INFO or WARNING,
+        never ERROR. We pick WARNING so it mirrors the normal
+        ``level_for_status(404)`` result and consumers see a single rule:
+        "4xx → warning". Emits ``request_completed`` (not ``request_failed``)
+        because a 404 is an ordinary outcome, not a server-side failure.
+        """
+        elapsed = duration_ms(start, time.monotonic())
+        self._logger.set_context_field("http.response.status_code", _STATUS_NOT_FOUND)
+        self._logger.set_context_field("duration_ms", elapsed)
+        # Record the exception type without a traceback since Http404 is a
+        # control-flow signal, not a crash. ``error.type`` uses the status
+        # code string to match the non-exception 4xx path.
+        self._logger.set_context_field("exception.type", type(exc).__name__)
+        self._logger.set_context_field("error.type", str(_STATUS_NOT_FOUND))
+        self._logger.warning(_EVENT_COMPLETED)
+
+    def _emit_failed(self, start: float, exc: Exception) -> None:
+        """Log an unhandled exception at ERROR and synthesise status 500.
+
+        Must be called from inside the ``except`` block so ``logger.exception``
+        picks up ``sys.exc_info`` correctly (Art. 42).
+        """
+        elapsed = duration_ms(start, time.monotonic())
+        self._logger.set_context_field("exception.type", type(exc).__name__)
+        self._logger.set_context_field("http.response.status_code", _STATUS_SYNTH_ON_EXCEPTION)
+        self._logger.set_context_field("duration_ms", elapsed)
+        # (Art. 50 + OTel) ``error.type`` on the exception path uses the
+        # fully-qualified class name per HTTP server semconv note 4
+        # ("exception type (its fully-qualified class name, if applicable)").
+        cls = type(exc)
+        fqn = f"{cls.__module__}.{cls.__qualname__}"
+        self._logger.set_context_field("error.type", fqn)
+        self._logger.exception(_EVENT_FAILED)
+
+    # --- private helpers ----------------------------------------------------
+
+    def _bind_request_ids(self, request: HttpRequest) -> None:
+        """Bind ``request_id`` (always fresh) and optional ``upstream_request_id``.
+
+        Constitution Art. 32: ``request_id`` MUST be a fresh per-hop UUID4,
+        distinct from any inbound correlation value. Art. 30: inbound
+        ``X-Request-ID`` is accepted verbatim, length-capped, and charset-
+        restricted (security finding A3, block log-injection / log-search
+        hijack via attacker-chosen identifiers). When validation rejects an
+        inbound value, ``upstream_request_id`` is simply omitted; the
+        locally-minted ``request_id`` is unaffected.
+        """
+        self._logger.set_context_field("request_id", uuid.uuid4().hex)
+
+        raw = request.headers.get(X_REQUEST_ID)
+        validated = validate_request_id(raw) if raw is not None else None
+        if validated is not None:
+            self._logger.set_context_field("upstream_request_id", validated)
+
+    def _bind_allowlisted_headers(self, request: HttpRequest) -> None:
+        if not self._header_allowlist:
+            return
+        for header_name in self._header_allowlist:
+            raw = request.headers.get(header_name)
+            if raw is None:
+                continue
+            value = truncate(raw, MAX_HEADER_VALUE)
+            normalised = header_name.lower().replace("-", "_")
+            self._logger.set_context_field(f"http.request.header.{normalised}", value or "")
+
+    def _emit(self, level: str, event: str) -> None:
+        """Dispatch to the correct logger method based on computed level."""
+        if level == LEVEL_ERROR:
+            self._logger.error(event)
+        elif level == LEVEL_WARNING:
+            self._logger.warning(event)
+        else:
+            self._logger.info(event)
+
+
+__all__ = ["StructuredLoggingMiddlewareOTel"]

--- a/src/i_dot_ai_utilities/logging/middleware/django_user_id.py
+++ b/src/i_dot_ai_utilities/logging/middleware/django_user_id.py
@@ -19,7 +19,7 @@ live inside the deleted ``DjangoEnricher``:
   ``LazyObject.__class__`` proxy, so it never forces evaluation) plus an
   identity check against Django's ``empty`` sentinel.
 
-- Art. 46 / resilience: any database-layer exception raised during
+- Resilience: any database-layer exception raised during
   attribute access is surfaced via a WARNING rather than swallowed so
   DB outages remain visible in the very logs that would diagnose them.
   Detection is by MRO class-name match (``DatabaseError`` and

--- a/src/i_dot_ai_utilities/logging/middleware/django_user_id.py
+++ b/src/i_dot_ai_utilities/logging/middleware/django_user_id.py
@@ -1,0 +1,231 @@
+"""Django ``DjangoUserIdMiddleware``: bind ``user.id`` to structlog context.
+
+The OTel-backed ``StructuredLoggingMiddlewareOTel`` deliberately drops
+``user.id`` extraction: OpenTelemetry's Django auto-instrumentation does
+not surface the authenticated user, and baking the extraction into the
+main middleware would re-entangle this library with Django's auth model.
+
+This thin middleware fills that gap for consumers who want authenticated
+user attribution on log records. It lifts the safety work that used to
+live inside the deleted ``DjangoEnricher``:
+
+- Finding FI-5: observability code MUST NOT issue a database query.
+  ``request.user`` is often a ``django.utils.functional.SimpleLazyObject``
+  that hydrates via the auth backend on first attribute access. Touching
+  ``.pk`` on an unhydrated instance triggers a ``User.objects.get(...)``,
+  which both adds query load and masks DB outages (the query fails, the
+  log line silently loses ``user.id``, the operator can't correlate).
+  We detect the unhydrated state by class name (which does not trip the
+  ``LazyObject.__class__`` proxy, so it never forces evaluation) plus an
+  identity check against Django's ``empty`` sentinel.
+
+- Art. 46 / resilience: any database-layer exception raised during
+  attribute access is surfaced via a WARNING rather than swallowed so
+  DB outages remain visible in the very logs that would diagnose them.
+  Detection is by MRO class-name match (``DatabaseError`` and
+  subclasses) so this module stays importable without ``django.db``.
+
+Wire into ``settings.MIDDLEWARE`` *after* Django's
+``AuthenticationMiddleware`` (so ``request.user`` exists) AND *after*
+``StructuredLoggingMiddlewareOTel`` (so the request scope is active and
+``set_context_field`` lands on the correct request context)::
+
+    MIDDLEWARE = [
+        "django.middleware.security.SecurityMiddleware",
+        "django.contrib.sessions.middleware.SessionMiddleware",
+        "django.contrib.auth.middleware.AuthenticationMiddleware",
+        "i_dot_ai_utilities.logging.middleware.django_otel.StructuredLoggingMiddlewareOTel",
+        "i_dot_ai_utilities.logging.middleware.django_user_id.DjangoUserIdMiddleware",
+        # ... your other middleware
+    ]
+
+Sync-only by design (``sync_capable = True``, ``async_capable = False``)
+to match ``StructuredLoggingMiddlewareOTel``.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING, Any, ClassVar, Final
+
+from django.conf import settings  # type: ignore[import-untyped]
+from django.core.exceptions import MiddlewareNotUsed  # type: ignore[import-untyped]
+from django.utils.functional import empty  # type: ignore[import-untyped]
+
+from i_dot_ai_utilities.logging.middleware._settings import (
+    SETTING_ENABLED,
+    SETTING_LOGGER,
+    resolve_logger,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from django.http import HttpRequest, HttpResponse  # type: ignore[import-untyped]
+
+
+# Django database-layer exception class names. Matched structurally by MRO
+# class name so this module can stay free of a top-level ``django.db``
+# import (verified by ``test_optional_django_import.py``'s defence-in-depth
+# grep). The set mirrors the Django DB exception hierarchy that has been
+# stable since 1.x; if a new subclass ever slips through, the outer
+# ``except Exception`` still catches it, we just lose the dedicated
+# WARNING and fall back to silent skip.
+_DB_ERROR_CLASS_NAMES: Final[frozenset[str]] = frozenset(
+    {
+        "DatabaseError",
+        "OperationalError",
+        "InterfaceError",
+        "ProgrammingError",
+        "IntegrityError",
+    }
+)
+
+
+def _is_database_error(exc: BaseException) -> bool:
+    """Return True if ``exc`` looks like a Django database-layer exception."""
+    return any(cls.__name__ in _DB_ERROR_CLASS_NAMES for cls in type(exc).__mro__)
+
+
+def _looks_like_unhydrated_lazy_object(user: Any) -> bool:
+    """Detect Django's ``SimpleLazyObject`` before it has hydrated.
+
+    ``type(user).__name__`` is used for the class check because it reads the
+    real type without going through ``LazyObject.__class__`` (a proxy that
+    would force evaluation). Django's unhydrated marker is ``_wrapped is
+    empty``, where ``empty`` is a bare ``object()`` whose class name is
+    ``"object"``, so only an identity comparison can recognise it. Reading
+    ``_wrapped`` is a plain instance-dict lookup and does not hydrate.
+    """
+    if type(user).__name__ != "SimpleLazyObject":
+        return False
+    return getattr(user, "_wrapped", empty) is empty
+
+
+class DjangoUserIdMiddleware:
+    """Bind ``user.id`` onto the structlog context after authentication runs.
+
+    Emits nothing when ``request.user`` is absent, anonymous, or an
+    unhydrated lazy object. Emits a WARNING when a database-layer
+    exception is raised while reading the user; the request continues
+    unaffected.
+    """
+
+    sync_capable: ClassVar[bool] = True
+    async_capable: ClassVar[bool] = False
+
+    def __init__(self, get_response: Callable[[HttpRequest], HttpResponse]) -> None:
+        self._get_response = get_response
+
+        enabled = getattr(settings, SETTING_ENABLED, True)
+        if not enabled:
+            # Mirror the other middlewares: clean removal via MiddlewareNotUsed
+            # rather than a silent no-op.
+            msg = "DjangoUserIdMiddleware disabled via settings."
+            raise MiddlewareNotUsed(msg)
+
+        self._logger = resolve_logger(getattr(settings, SETTING_LOGGER, None))
+
+    def __call__(self, request: HttpRequest) -> HttpResponse:
+        # Bind first, then call through. Binding after the view would miss
+        # log events emitted inside the view itself, since the whole point is to
+        # tag every in-request log line with the acting user.
+        self._bind_user_id(request)
+        return self._get_response(request)
+
+    def process_exception(
+        self,
+        request: HttpRequest,
+        exception: BaseException,
+    ) -> None:
+        """No-op: matches the finding-A7 contract on the other middlewares.
+
+        ``request`` and ``exception`` are accepted for parity with Django's
+        middleware protocol; intentionally unused.
+        """
+
+    # --- private helpers ----------------------------------------------------
+
+    def _bind_user_id(self, request: HttpRequest) -> None:
+        """Best-effort ``user.id`` extraction. Never raises."""
+        try:
+            user_id = self._extract_user_id(request)
+        except Exception:  # noqa: BLE001 - observability must not break the request
+            # Defence in depth: any path that escapes the inner handlers
+            # still must not take the request down.
+            return
+
+        if user_id is not None:
+            self._logger.set_context_field("user.id", user_id)
+
+    def _extract_user_id(self, request: HttpRequest) -> str | None:
+        """Return ``str(pk)`` for the authenticated user, or ``None``.
+
+        Returns ``None`` for every "we shouldn't emit user.id" path:
+        missing ``request.user``, unhydrated lazy object, anonymous or
+        non-strictly-True ``is_authenticated``, attribute-access DB
+        errors (which are surfaced via WARNING before returning), and
+        ``pk``/``id`` both absent.
+        """
+        user = getattr(request, "user", None)
+        if user is None:
+            return None
+
+        # FI-5: never force hydration of a lazy user.
+        if _looks_like_unhydrated_lazy_object(user):
+            return None
+
+        if not self._user_is_authenticated(user):
+            return None
+
+        return self._read_user_pk(user)
+
+    def _user_is_authenticated(self, user: Any) -> bool:
+        """Safely read ``is_authenticated``. Returns False on DB errors
+        (after emitting a WARNING) or any other failure.
+        """
+        try:
+            is_authenticated_attr = getattr(user, "is_authenticated", None)
+        except Exception as exc:  # noqa: BLE001 - best-effort enrichment
+            if _is_database_error(exc):
+                self._warn_db_error(
+                    "Warning(Logger): Database error reading request.user.is_authenticated; "
+                    "user.id omitted from log context"
+                )
+            return False
+        # Strict ``is True`` per the FI-5 contract: truthy-but-not-True
+        # sentinels (mock objects, duck-typed surrogates) must not cause
+        # a pk lookup.
+        return is_authenticated_attr is True
+
+    def _read_user_pk(self, user: Any) -> str | None:
+        """Read ``pk`` (or ``id`` as fallback) and stringify it. Returns
+        ``None`` on DB errors or when both are absent.
+        """
+        try:
+            user_id_attr = getattr(user, "pk", None)
+            if user_id_attr is None:
+                user_id_attr = getattr(user, "id", None)
+        except Exception as exc:  # noqa: BLE001 - best-effort enrichment
+            if _is_database_error(exc):
+                self._warn_db_error(
+                    "Warning(Logger): Database error reading request.user primary key; user.id omitted from log context"
+                )
+            return None
+
+        if user_id_attr is None:
+            return None
+        return str(user_id_attr)
+
+    def _warn_db_error(self, message: str) -> None:
+        """Emit a WARNING without letting a broken logger crash the request."""
+        try:
+            self._logger.warning(message)
+        except Exception as exc:  # noqa: BLE001 - last-resort observability
+            print(  # noqa: T201
+                f"i_dot_ai_utilities: user.id db-error warning failed: {type(exc).__name__}: {exc}",
+                file=sys.stderr,
+            )
+
+
+__all__ = ["DjangoUserIdMiddleware"]

--- a/src/i_dot_ai_utilities/logging/structured_logger.py
+++ b/src/i_dot_ai_utilities/logging/structured_logger.py
@@ -28,25 +28,12 @@ if TYPE_CHECKING:
     from i_dot_ai_utilities.logging.types.lambda_enrichment_schema import ExtractedLambdaContext
 
 
-# ---------------------------------------------------------------------------
-# Request-scope ownership
-# ---------------------------------------------------------------------------
-#
 # When a framework integration (e.g. ``StructuredLoggingMiddlewareOTel``) owns the
-# lifecycle of the structured-log context for the duration of a request, it
-# sets this contextvar with a sentinel token before rebuilding the context and
-# clears it in ``finally``. Inside that window, manual ``refresh_context``
-# calls with ``scope="manual"`` or ``scope="request"`` (typically from views
-# or helper utilities written before the middleware existed) are downgraded
-# to no-ops and a warning is emitted.
-#
-# The goal is to eliminate the silent de-correlation described in the security
-# review's residual finding: two independent callers fighting over the same
-# mutable ``structlog.contextvars`` state produce logs that look coherent but
-# are causally disconnected from the originating request.
-#
-# Job workers (e.g. RQ / Celery) legitimately need to reset context per-job
-# and pass ``scope="job"`` to opt out of the ownership check.
+# request's log context, it claims this contextvar for the request's duration and
+# manual ``refresh_context`` calls (scope "manual"/"request") are downgraded to
+# no-ops. Two callers mutating the same ``structlog.contextvars`` state would
+# otherwise silently de-correlate a request's logs. Job workers pass ``scope="job"``
+# to opt out and reset context per-job.
 
 REQUEST_SCOPE_OWNER_MIDDLEWARE: str = "middleware"
 
@@ -222,13 +209,12 @@ class StructuredLogger:
         """Reset the logger, creating a new context id and removing any custom fields set since the previous invocation.
 
         :param context_enrichers: A list of one or more ContextEnrichmentOptions. Used to refresh the new logger with fields from well-known frameworks, such as FastAPI request metadata.
-        :param scope: The scope of the refresh. Callers inside a framework
+        :param scope: The scope of the refresh. Calls inside a framework
             integration that already owns the request's log-context lifecycle
-            (e.g. Django's ``StructuredLoggingMiddlewareOTel``) should be treated
-            as no-ops to avoid silent de-correlation of audit trails
-            (security finding: residual flaw). Pass ``"job"`` for background
-            workers that legitimately need to reset per-job context regardless
-            of any request scope. Defaults to ``"manual"``.
+            (e.g. Django's ``StructuredLoggingMiddlewareOTel``) are treated as
+            no-ops to avoid silently de-correlating a request's logs. Pass
+            ``"job"`` for background workers that legitimately need to reset
+            per-job context regardless of any request scope. Defaults to ``"manual"``.
         """  # noqa: E501
         owner = _request_scope_owner.get()
         if owner is not None and scope in ("request", "manual"):

--- a/src/i_dot_ai_utilities/logging/structured_logger.py
+++ b/src/i_dot_ai_utilities/logging/structured_logger.py
@@ -2,7 +2,8 @@ import json
 import logging
 import os
 import uuid
-from typing import TYPE_CHECKING, Any
+from contextvars import ContextVar
+from typing import TYPE_CHECKING, Any, Literal
 
 import structlog
 
@@ -25,6 +26,43 @@ if TYPE_CHECKING:
     from i_dot_ai_utilities.logging.types.base_context import BaseContext
     from i_dot_ai_utilities.logging.types.fastapi_enrichment_schema import ExtractedFastApiContext
     from i_dot_ai_utilities.logging.types.lambda_enrichment_schema import ExtractedLambdaContext
+
+
+# ---------------------------------------------------------------------------
+# Request-scope ownership
+# ---------------------------------------------------------------------------
+#
+# When a framework integration (e.g. ``StructuredLoggingMiddlewareOTel``) owns the
+# lifecycle of the structured-log context for the duration of a request, it
+# sets this contextvar with a sentinel token before rebuilding the context and
+# clears it in ``finally``. Inside that window, manual ``refresh_context``
+# calls with ``scope="manual"`` or ``scope="request"`` (typically from views
+# or helper utilities written before the middleware existed) are downgraded
+# to no-ops and a warning is emitted.
+#
+# The goal is to eliminate the silent de-correlation described in the security
+# review's residual finding: two independent callers fighting over the same
+# mutable ``structlog.contextvars`` state produce logs that look coherent but
+# are causally disconnected from the originating request.
+#
+# Job workers (e.g. RQ / Celery) legitimately need to reset context per-job
+# and pass ``scope="job"`` to opt out of the ownership check.
+
+REQUEST_SCOPE_OWNER_MIDDLEWARE: str = "middleware"
+
+_request_scope_owner: ContextVar[str | None] = ContextVar("i_dot_ai_utilities_request_scope_owner", default=None)
+
+RefreshScope = Literal["request", "job", "manual"]
+
+
+def _claim_request_scope(owner: str) -> object:
+    """Install a scope-ownership token. Returns the reset token for cleanup."""
+    return _request_scope_owner.set(owner)
+
+
+def _release_request_scope(token: object) -> None:
+    """Release a previously installed ownership token."""
+    _request_scope_owner.reset(token)  # type: ignore[arg-type]
 
 
 class StructuredLogger:
@@ -176,17 +214,55 @@ class StructuredLogger:
         safe_kwargs = self._normalise_kwargs(**{field_key: field_value})
         structlog.contextvars.bind_contextvars(**safe_kwargs)
 
-    def refresh_context(self, context_enrichers: list[ContextEnrichmentOptions] | None = None) -> None:
+    def refresh_context(
+        self,
+        context_enrichers: list[ContextEnrichmentOptions] | None = None,
+        scope: RefreshScope = "manual",
+    ) -> None:
         """Reset the logger, creating a new context id and removing any custom fields set since the previous invocation.
 
         :param context_enrichers: A list of one or more ContextEnrichmentOptions. Used to refresh the new logger with fields from well-known frameworks, such as FastAPI request metadata.
+        :param scope: The scope of the refresh. Callers inside a framework
+            integration that already owns the request's log-context lifecycle
+            (e.g. Django's ``StructuredLoggingMiddlewareOTel``) should be treated
+            as no-ops to avoid silent de-correlation of audit trails
+            (security finding: residual flaw). Pass ``"job"`` for background
+            workers that legitimately need to reset per-job context regardless
+            of any request scope. Defaults to ``"manual"``.
         """  # noqa: E501
+        owner = _request_scope_owner.get()
+        if owner is not None and scope in ("request", "manual"):
+            # A framework integration already owns the request-scoped context
+            # for this request. Skipping the clear prevents a second caller
+            # (view function, helper, third-party middleware) from wiping the
+            # middleware-bound trace_id / request_id / user attribution
+            # mid-request and producing log lines that cannot be correlated
+            # back to the originating HTTP request.
+            self._logger.warning(
+                "Warning(Logger): refresh_context called inside an active "
+                "middleware-owned request scope; clear skipped to preserve "
+                "request correlation. Pass scope='job' from background "
+                "workers that legitimately need to reset context.",
+                requested_scope=scope,
+                active_scope_owner=owner,
+            )
+            if context_enrichers is None:
+                return
+            # Still apply any new enrichers on top of the owned context so
+            # callers adding context aren't silently dropped, just don't
+            # clear what the middleware already bound.
+            self._apply_enrichers(context_enrichers)
+            return
+
         structlog.contextvars.clear_contextvars()
         self._upsert_base_context()
 
         if context_enrichers is None:
             return
 
+        self._apply_enrichers(context_enrichers)
+
+    def _apply_enrichers(self, context_enrichers: list[ContextEnrichmentOptions]) -> None:
         additional_context: ExtractedFastApiContext | ExtractedLambdaContext | dict[str, Any] = {}
         for enricher in context_enrichers:
             enricher_type = enricher["type"]

--- a/uv.lock
+++ b/uv.lock
@@ -1172,7 +1172,6 @@ all = [
     { name = "minio" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
-    { name = "opentelemetry-instrumentation-asgi" },
     { name = "opentelemetry-instrumentation-django" },
     { name = "opentelemetry-instrumentation-fastapi" },
     { name = "opentelemetry-propagator-aws-xray" },
@@ -1215,8 +1214,21 @@ litellm = [
 otel = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
-    { name = "opentelemetry-instrumentation-asgi" },
+    { name = "opentelemetry-propagator-aws-xray" },
+    { name = "opentelemetry-sdk" },
+    { name = "opentelemetry-sdk-extension-aws" },
+]
+otel-django = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-instrumentation-django" },
+    { name = "opentelemetry-propagator-aws-xray" },
+    { name = "opentelemetry-sdk" },
+    { name = "opentelemetry-sdk-extension-aws" },
+]
+otel-fastapi = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-instrumentation-fastapi" },
     { name = "opentelemetry-propagator-aws-xray" },
     { name = "opentelemetry-sdk" },
@@ -1232,7 +1244,6 @@ dev = [
     { name = "mypy" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
-    { name = "opentelemetry-instrumentation-asgi" },
     { name = "opentelemetry-instrumentation-django" },
     { name = "opentelemetry-instrumentation-fastapi" },
     { name = "opentelemetry-propagator-aws-xray" },
@@ -1266,9 +1277,11 @@ requires-dist = [
     { name = "google-cloud-storage", marker = "extra == 'file-store'", specifier = ">=3.3.1" },
     { name = "grpcio-status", marker = "extra == 'all'", specifier = ">=1.76.0" },
     { name = "grpcio-status", marker = "extra == 'file-store'", specifier = ">=1.76.0" },
+    { name = "i-dot-ai-utilities", extras = ["otel"], marker = "extra == 'otel-django'" },
+    { name = "i-dot-ai-utilities", extras = ["otel"], marker = "extra == 'otel-fastapi'" },
     { name = "langfuse", marker = "extra == 'all'", specifier = ">=3.4.0" },
     { name = "langfuse", marker = "extra == 'litellm'", specifier = ">=3.4.0" },
-    { name = "litellm", marker = "extra == 'all'", specifier = ">=1.77.1" },
+    { name = "litellm", marker = "extra == 'all'", specifier = "==1.79.0" },
     { name = "litellm", marker = "extra == 'litellm'", specifier = "==1.79.0" },
     { name = "minio", marker = "extra == 'all'", specifier = ">=7.2.15" },
     { name = "minio", marker = "extra == 'file-store'", specifier = ">=7.2.15" },
@@ -1279,12 +1292,10 @@ requires-dist = [
     { name = "opentelemetry-exporter-otlp", marker = "extra == 'litellm'", specifier = ">=1.37.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'all'", specifier = ">=1.27" },
     { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'otel'", specifier = ">=1.27" },
-    { name = "opentelemetry-instrumentation-asgi", marker = "extra == 'all'", specifier = ">=0.48b0" },
-    { name = "opentelemetry-instrumentation-asgi", marker = "extra == 'otel'", specifier = ">=0.48b0" },
     { name = "opentelemetry-instrumentation-django", marker = "extra == 'all'", specifier = ">=0.48b0" },
-    { name = "opentelemetry-instrumentation-django", marker = "extra == 'otel'", specifier = ">=0.48b0" },
+    { name = "opentelemetry-instrumentation-django", marker = "extra == 'otel-django'", specifier = ">=0.48b0" },
     { name = "opentelemetry-instrumentation-fastapi", marker = "extra == 'all'", specifier = ">=0.48b0" },
-    { name = "opentelemetry-instrumentation-fastapi", marker = "extra == 'otel'", specifier = ">=0.48b0" },
+    { name = "opentelemetry-instrumentation-fastapi", marker = "extra == 'otel-fastapi'", specifier = ">=0.48b0" },
     { name = "opentelemetry-propagator-aws-xray", marker = "extra == 'all'", specifier = ">=1.0.1" },
     { name = "opentelemetry-propagator-aws-xray", marker = "extra == 'otel'", specifier = ">=1.0.1" },
     { name = "opentelemetry-sdk", marker = "extra == 'all'", specifier = ">=1.27" },
@@ -1305,7 +1316,7 @@ requires-dist = [
     { name = "structlog", specifier = ">=25.4.0" },
     { name = "typing-extensions", specifier = ">=4.0.0" },
 ]
-provides-extras = ["dev", "auth", "file-store", "litellm", "metrics", "django", "otel", "all"]
+provides-extras = ["dev", "auth", "file-store", "litellm", "metrics", "django", "otel", "otel-django", "otel-fastapi", "all"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1316,7 +1327,6 @@ dev = [
     { name = "mypy", specifier = ">=1.15.0" },
     { name = "opentelemetry-api", specifier = ">=1.27" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.27" },
-    { name = "opentelemetry-instrumentation-asgi", specifier = ">=0.48b0" },
     { name = "opentelemetry-instrumentation-django", specifier = ">=0.48b0" },
     { name = "opentelemetry-instrumentation-fastapi", specifier = ">=0.48b0" },
     { name = "opentelemetry-propagator-aws-xray", specifier = ">=1.0.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -2969,11 +2969,11 @@ wheels = [
 
 [[package]]
 name = "sqlparse"
-version = "0.5.5"
+version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/90/76/437d71068094df0726366574cf3432a4ed754217b436eb7429415cf2d480/sqlparse-0.5.5.tar.gz", hash = "sha256:e20d4a9b0b8585fdf63b10d30066c7c94c5d7a7ec47c889a2d83a3caa93ff28e", size = 120815, upload-time = "2025-12-19T07:17:45.073Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/d3/3f06a1006f2261d1342aefb3c71eed02f5d4ca5bdbecd86ebc12ad38306e/sqlparse-0.6.0.tar.gz", hash = "sha256:113c35c75365ab9cc9c7231d68c6428fb11c085fc8e9eb1ad659b7ddbf6cd2b9", size = 178477, upload-time = "2026-08-13T19:16:06.396Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/4b/359f28a903c13438ef59ebeee215fb25da53066db67b305c125f1c6d2a25/sqlparse-0.5.5-py3-none-any.whl", hash = "sha256:12a08b3bf3eec877c519589833aed092e2444e68240a3577e8e26148acc7b1ba", size = 46138, upload-time = "2025-12-19T07:17:46.573Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/50/f00935da0ec7cbf325f8dc4f772ae46fbc7b672dd62876e73f0a94adda57/sqlparse-0.6.0-py3-none-any.whl", hash = "sha256:b861c0288ce2fa56209a9a6412d2e066ac664b3873b89c26c9d8415e8e32996f", size = 50070, upload-time = "2026-08-13T19:16:04.062Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -115,6 +115,15 @@ wheels = [
 ]
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/8e/38aa427ed5402449e226975b649c5dc73ccadfefeb95e6aecb8f8ea4b6b6/annotated_doc-0.0.5.tar.gz", hash = "sha256:c7e58ce09192557605d8bbd92836d7e1d520ac9580096042c0bfd197efacf1bb", size = 10758, upload-time = "2026-07-28T13:50:58.129Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/30/e900b21425a860e195f32e37657aa1f7c7f2b1bfb26f03ca209b90933c06/annotated_doc-0.0.5-py3-none-any.whl", hash = "sha256:117bac03a25ede5df5440e855b32d556049ca169ead221505badf432fed4b101", size = 5302, upload-time = "2026-07-28T13:50:57.239Z" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -169,6 +178,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/95/143cd64feb24a15fa4b189a3e1e7efbaeeb00f39a51e99b26fc62fbacabd/argon2_cffi_bindings-21.2.0-cp36-abi3-win32.whl", hash = "sha256:603ca0aba86b1349b147cab91ae970c63118a0f30444d4bc80355937c950c082", size = 27698, upload-time = "2021-12-01T09:09:27.87Z" },
     { url = "https://files.pythonhosted.org/packages/37/2c/e34e47c7dee97ba6f01a6203e0383e15b60fb85d78ac9a15cd066f6fe28b/argon2_cffi_bindings-21.2.0-cp36-abi3-win_amd64.whl", hash = "sha256:b2ef1c30440dbbcba7a5dc3e319408b59676e2e039e2ae11a8775ecf482b192f", size = 30817, upload-time = "2021-12-01T09:09:30.267Z" },
     { url = "https://files.pythonhosted.org/packages/5a/e4/bf8034d25edaa495da3c8a3405627d2e35758e44ff6eaa7948092646fdcc/argon2_cffi_bindings-21.2.0-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:e415e3f62c8d124ee16018e491a009937f8cf7ebf5eb430ffc5de21b900dad93", size = 53104, upload-time = "2021-12-01T09:09:31.335Z" },
+]
+
+[[package]]
+name = "asgiref"
+version = "3.11.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/63/40/f03da1264ae8f7cfdbf9146542e5e7e8100a4c66ab48e791df9a03d3f6c0/asgiref-3.11.1.tar.gz", hash = "sha256:5f184dc43b7e763efe848065441eac62229c9f7b0475f41f80e207a114eda4ce", size = 38550, upload-time = "2026-02-03T13:30:14.33Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/0a/a72d10ed65068e115044937873362e6e32fab1b7dce0046aeb224682c989/asgiref-3.11.1-py3-none-any.whl", hash = "sha256:e8667a091e69529631969fd45dc268fa79b99c92c5fcdda727757e52146ec133", size = 24345, upload-time = "2026-02-03T13:30:13.039Z" },
 ]
 
 [[package]]
@@ -641,6 +662,20 @@ wheels = [
 ]
 
 [[package]]
+name = "django"
+version = "5.2.13"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asgiref" },
+    { name = "sqlparse" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/c5/c69e338eb2959f641045802e5ea87ca4bf5ac90c5fd08953ca10742fad51/django-5.2.13.tar.gz", hash = "sha256:a31589db5188d074c63f0945c3888fad104627dfcc236fb2b97f71f89da33bc4", size = 10890368, upload-time = "2026-04-07T14:02:15.072Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/b1/51ab36b2eefcf8cdb9338c7188668a157e29e30306bfc98a379704c9e10d/django-5.2.13-py3-none-any.whl", hash = "sha256:5788fce61da23788a8ce6f02583765ab060d396720924789f97fa42119d37f7a", size = 8310982, upload-time = "2026-04-07T14:02:08.883Z" },
+]
+
+[[package]]
 name = "ecologits"
 version = "0.8.2"
 source = { registry = "https://pypi.org/simple" }
@@ -664,6 +699,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/09/35/2495c4ac46b980e4ca1f6ad6db102322ef3ad2410b79fdde159a4b0f3b92/exceptiongroup-1.2.2.tar.gz", hash = "sha256:47c2edf7c6738fafb49fd34290706d1a1a2f4d1c6df275526b62cbb4aa5393cc", size = 28883, upload-time = "2024-07-12T22:26:00.161Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/02/cc/b7e31358aac6ed1ef2bb790a9746ac2c69bcb3c8588b41616914eb106eaf/exceptiongroup-1.2.2-py3-none-any.whl", hash = "sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b", size = 16453, upload-time = "2024-07-12T22:25:58.476Z" },
+]
+
+[[package]]
+name = "fastapi"
+version = "0.141.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8a/02/91e3416a8fdd715abb903a952a6bec7cdd8d14eed55d415fc8595524c319/fastapi-0.141.1.tar.gz", hash = "sha256:e8822fc40db1e1858054d7a949a888695bc9bdce70139178e33bd2871a453ca1", size = 425799, upload-time = "2026-07-29T17:18:05.568Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/03/10388a42375ee7e4ac9b94eb2c5c569c8b5795e377e701c9ac3ad63de890/fastapi-0.141.1-py3-none-any.whl", hash = "sha256:bfb91aa2d334c61cb35ba9a116fc123b3d3df31640b801cf57a7a78ec3f603b3", size = 131954, upload-time = "2026-07-29T17:18:04.364Z" },
 ]
 
 [[package]]
@@ -1112,11 +1163,21 @@ all = [
     { name = "azure-storage-blob" },
     { name = "boto3" },
     { name = "boto3-stubs", extra = ["s3"] },
+    { name = "django" },
     { name = "ecologits" },
     { name = "google-cloud-storage" },
+    { name = "grpcio-status" },
     { name = "langfuse" },
     { name = "litellm" },
     { name = "minio" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-instrumentation-asgi" },
+    { name = "opentelemetry-instrumentation-django" },
+    { name = "opentelemetry-instrumentation-fastapi" },
+    { name = "opentelemetry-propagator-aws-xray" },
+    { name = "opentelemetry-sdk" },
+    { name = "opentelemetry-sdk-extension-aws" },
     { name = "rapidfuzz" },
     { name = "requests" },
 ]
@@ -1128,6 +1189,9 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
+]
+django = [
+    { name = "django" },
 ]
 file-store = [
     { name = "azure-core" },
@@ -1148,11 +1212,32 @@ litellm = [
     { name = "rapidfuzz" },
     { name = "requests" },
 ]
+otel = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-instrumentation-asgi" },
+    { name = "opentelemetry-instrumentation-django" },
+    { name = "opentelemetry-instrumentation-fastapi" },
+    { name = "opentelemetry-propagator-aws-xray" },
+    { name = "opentelemetry-sdk" },
+    { name = "opentelemetry-sdk-extension-aws" },
+]
 
 [package.dev-dependencies]
 dev = [
     { name = "bandit" },
+    { name = "django" },
+    { name = "fastapi" },
+    { name = "httpx" },
     { name = "mypy" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-instrumentation-asgi" },
+    { name = "opentelemetry-instrumentation-django" },
+    { name = "opentelemetry-instrumentation-fastapi" },
+    { name = "opentelemetry-propagator-aws-xray" },
+    { name = "opentelemetry-sdk" },
+    { name = "opentelemetry-sdk-extension-aws" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -1173,10 +1258,13 @@ requires-dist = [
     { name = "boto3", marker = "extra == 'file-store'", specifier = ">=1.40.41" },
     { name = "boto3-stubs", extras = ["s3"], marker = "extra == 'all'", specifier = ">=1.40.41" },
     { name = "boto3-stubs", extras = ["s3"], marker = "extra == 'file-store'", specifier = ">=1.40.41" },
+    { name = "django", marker = "extra == 'all'", specifier = ">=4.2,<6.0" },
+    { name = "django", marker = "extra == 'django'", specifier = ">=4.2,<6.0" },
     { name = "ecologits", marker = "extra == 'all'", specifier = ">=0.8.2" },
     { name = "ecologits", marker = "extra == 'litellm'", specifier = ">=0.8.2" },
     { name = "google-cloud-storage", marker = "extra == 'all'", specifier = ">=3.3.1" },
     { name = "google-cloud-storage", marker = "extra == 'file-store'", specifier = ">=3.3.1" },
+    { name = "grpcio-status", marker = "extra == 'all'", specifier = ">=1.76.0" },
     { name = "grpcio-status", marker = "extra == 'file-store'", specifier = ">=1.76.0" },
     { name = "langfuse", marker = "extra == 'all'", specifier = ">=3.4.0" },
     { name = "langfuse", marker = "extra == 'litellm'", specifier = ">=3.4.0" },
@@ -1185,9 +1273,25 @@ requires-dist = [
     { name = "minio", marker = "extra == 'all'", specifier = ">=7.2.15" },
     { name = "minio", marker = "extra == 'file-store'", specifier = ">=7.2.15" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.15.0" },
+    { name = "opentelemetry-api", marker = "extra == 'all'", specifier = ">=1.27" },
     { name = "opentelemetry-api", marker = "extra == 'litellm'", specifier = ">=1.37.0" },
+    { name = "opentelemetry-api", marker = "extra == 'otel'", specifier = ">=1.27" },
     { name = "opentelemetry-exporter-otlp", marker = "extra == 'litellm'", specifier = ">=1.37.0" },
+    { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'all'", specifier = ">=1.27" },
+    { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'otel'", specifier = ">=1.27" },
+    { name = "opentelemetry-instrumentation-asgi", marker = "extra == 'all'", specifier = ">=0.48b0" },
+    { name = "opentelemetry-instrumentation-asgi", marker = "extra == 'otel'", specifier = ">=0.48b0" },
+    { name = "opentelemetry-instrumentation-django", marker = "extra == 'all'", specifier = ">=0.48b0" },
+    { name = "opentelemetry-instrumentation-django", marker = "extra == 'otel'", specifier = ">=0.48b0" },
+    { name = "opentelemetry-instrumentation-fastapi", marker = "extra == 'all'", specifier = ">=0.48b0" },
+    { name = "opentelemetry-instrumentation-fastapi", marker = "extra == 'otel'", specifier = ">=0.48b0" },
+    { name = "opentelemetry-propagator-aws-xray", marker = "extra == 'all'", specifier = ">=1.0.1" },
+    { name = "opentelemetry-propagator-aws-xray", marker = "extra == 'otel'", specifier = ">=1.0.1" },
+    { name = "opentelemetry-sdk", marker = "extra == 'all'", specifier = ">=1.27" },
     { name = "opentelemetry-sdk", marker = "extra == 'litellm'", specifier = ">=1.37.0" },
+    { name = "opentelemetry-sdk", marker = "extra == 'otel'", specifier = ">=1.27" },
+    { name = "opentelemetry-sdk-extension-aws", marker = "extra == 'all'", specifier = ">=2.0.0" },
+    { name = "opentelemetry-sdk-extension-aws", marker = "extra == 'otel'", specifier = ">=2.0.0" },
     { name = "pydantic", specifier = ">=2.11.9" },
     { name = "pydantic-settings", specifier = ">=2.10.1" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.5" },
@@ -1201,12 +1305,23 @@ requires-dist = [
     { name = "structlog", specifier = ">=25.4.0" },
     { name = "typing-extensions", specifier = ">=4.0.0" },
 ]
-provides-extras = ["dev", "auth", "file-store", "litellm", "metrics", "all"]
+provides-extras = ["dev", "auth", "file-store", "litellm", "metrics", "django", "otel", "all"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "bandit", specifier = ">=1.8.3" },
+    { name = "django", specifier = ">=4.2,<6.0" },
+    { name = "fastapi", specifier = ">=0.115" },
+    { name = "httpx", specifier = ">=0.27" },
     { name = "mypy", specifier = ">=1.15.0" },
+    { name = "opentelemetry-api", specifier = ">=1.27" },
+    { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.27" },
+    { name = "opentelemetry-instrumentation-asgi", specifier = ">=0.48b0" },
+    { name = "opentelemetry-instrumentation-django", specifier = ">=0.48b0" },
+    { name = "opentelemetry-instrumentation-fastapi", specifier = ">=0.48b0" },
+    { name = "opentelemetry-propagator-aws-xray", specifier = ">=1.0.1" },
+    { name = "opentelemetry-sdk", specifier = ">=1.27" },
+    { name = "opentelemetry-sdk-extension-aws", specifier = ">=2.0.0" },
     { name = "pre-commit", specifier = ">=4.2.0" },
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "pytest-cov", specifier = ">=6.1.1" },
@@ -1788,6 +1903,96 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-instrumentation"
+version = "0.58b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "packaging" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/36/7c307d9be8ce4ee7beb86d7f1d31027f2a6a89228240405a858d6e4d64f9/opentelemetry_instrumentation-0.58b0.tar.gz", hash = "sha256:df640f3ac715a3e05af145c18f527f4422c6ab6c467e40bd24d2ad75a00cb705", size = 31549, upload-time = "2025-09-11T11:42:14.084Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/db/5ff1cd6c5ca1d12ecf1b73be16fbb2a8af2114ee46d4b0e6d4b23f4f4db7/opentelemetry_instrumentation-0.58b0-py3-none-any.whl", hash = "sha256:50f97ac03100676c9f7fc28197f8240c7290ca1baa12da8bfbb9a1de4f34cc45", size = 33019, upload-time = "2025-09-11T11:41:00.624Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-asgi"
+version = "0.58b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asgiref" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7b/e2/03ff707d881d590c7adaed5e9d1979aed7e5e53fc1ed89035e5ed9f304af/opentelemetry_instrumentation_asgi-0.58b0.tar.gz", hash = "sha256:3ccc0c9c1c8c71e8d9da5945c6dcd9c0c8d147839f208536b7042c6dd98e65c9", size = 25116, upload-time = "2025-09-11T11:42:18.437Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8c/71/a00884c6655387c70070138acbf79a6616ad5d4489680f40708d75b598a7/opentelemetry_instrumentation_asgi-0.58b0-py3-none-any.whl", hash = "sha256:508a6d79e333d648d2afee0e140b6e80eb5d443be183be58e81d9ff88373168a", size = 16798, upload-time = "2025-09-11T11:41:08.105Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-django"
+version = "0.58b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-instrumentation-wsgi" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/69/e8/6055cb9129a5a80b8814b770b79ce559977ff3b3b11dfd4067566ff25c1d/opentelemetry_instrumentation_django-0.58b0.tar.gz", hash = "sha256:24f45706a9dc3c47b9214ed5422fd0d35a850f3f40b04112a91fc10561cfd3f5", size = 25009, upload-time = "2025-09-11T11:42:31.853Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/1a/396e941a7aae4e81793931a60669378c64a147a6dca75344b4c26cc8811b/opentelemetry_instrumentation_django-0.58b0-py3-none-any.whl", hash = "sha256:6e3ada766ce965e9486d193e10cb32749bd51fe1adb5ec6b9310e33fe89fad6d", size = 19596, upload-time = "2025-09-11T11:41:24.806Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-fastapi"
+version = "0.58b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-instrumentation-asgi" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/09/4f8fcab834af6b403e5e2d94bdfb2d0835ba8cd1049bcc156995f47b65fb/opentelemetry_instrumentation_fastapi-0.58b0.tar.gz", hash = "sha256:03da470d694116a0a40f4e76319e42f3ff9efc49abf804b2acc2c07f96661497", size = 24598, upload-time = "2025-09-11T11:42:35.325Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/fb/82de06eba54e5cb979274f073065ebc374794853502d342b5155073d1194/opentelemetry_instrumentation_fastapi-0.58b0-py3-none-any.whl", hash = "sha256:d89bfec69c9ffc5d9f3fe58655d6660a66b2bca863b9132712c06edcde68b6fa", size = 13460, upload-time = "2025-09-11T11:41:28.507Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-wsgi"
+version = "0.58b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3e/76/c33bb3f219dc2266f98b8f927e913e93b31e94af7aa6430a9a9f167f9ab2/opentelemetry_instrumentation_wsgi-0.58b0.tar.gz", hash = "sha256:0ea27d44c83b48e6b182a904c801ca62b2999642647f32ef33c8a9c8bbf6a245", size = 18377, upload-time = "2025-09-11T11:43:02.589Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/05/a168ba97831823e170937b4f1a0f95657c8bd9cc573c81629f464c3cc32b/opentelemetry_instrumentation_wsgi-0.58b0-py3-none-any.whl", hash = "sha256:cef5bdf1cb7a5162fdb1c1a2f95e4a08e02b1ca67ce828a1efdf81e9f23273b7", size = 14449, upload-time = "2025-09-11T11:42:05.323Z" },
+]
+
+[[package]]
+name = "opentelemetry-propagator-aws-xray"
+version = "1.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f4/31/40004e9e55b1e5694ef3a7526f0b7637df44196fc68a8b7d248a3684680f/opentelemetry_propagator_aws_xray-1.0.2.tar.gz", hash = "sha256:6b2cee5479d2ef0172307b66ed2ed151f598a0fd29b3c01133ac87ca06326260", size = 10994, upload-time = "2024-08-05T17:45:57.601Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/89/849a0847871fd9745315896ad9e23d6479db84d90b8b36c4c26dc46e92b8/opentelemetry_propagator_aws_xray-1.0.2-py3-none-any.whl", hash = "sha256:1c99181ee228e99bddb638a0c911a297fa21f1c3a0af951f841e79919b5f1934", size = 10856, upload-time = "2024-08-05T17:45:56.492Z" },
+]
+
+[[package]]
 name = "opentelemetry-proto"
 version = "1.37.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1814,6 +2019,18 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-sdk-extension-aws"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-sdk" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/b3/825c93fe4c238845f1356297abea33d03b2adaafb5ae98fc257b394de124/opentelemetry_sdk_extension_aws-2.1.0.tar.gz", hash = "sha256:ff68ddecc1910f62c019d22ec0f7461713ead7f662d6a2304d4089c1a0b20416", size = 16334, upload-time = "2024-12-24T15:01:57.387Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/61/47a6a43b7935d54b5734fbf3fb0357dd5a7d0dfaa9677b7318518fe8d507/opentelemetry_sdk_extension_aws-2.1.0-py3-none-any.whl", hash = "sha256:c7cf6efc275d2c24108a468d954287ce5aab9733bac816a080cfb3117374e63a", size = 18776, upload-time = "2024-12-24T15:01:56.053Z" },
+]
+
+[[package]]
 name = "opentelemetry-semantic-conventions"
 version = "0.58b0"
 source = { registry = "https://pypi.org/simple" }
@@ -1824,6 +2041,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/aa/1b/90701d91e6300d9f2fb352153fb1721ed99ed1f6ea14fa992c756016e63a/opentelemetry_semantic_conventions-0.58b0.tar.gz", hash = "sha256:6bd46f51264279c433755767bb44ad00f1c9e2367e1b42af563372c5a6fa0c25", size = 129867, upload-time = "2025-09-11T10:29:12.597Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/07/90/68152b7465f50285d3ce2481b3aec2f82822e3f52e5152eeeaf516bab841/opentelemetry_semantic_conventions-0.58b0-py3-none-any.whl", hash = "sha256:5564905ab1458b96684db1340232729fce3b5375a06e140e8904c78e4f815b28", size = 207954, upload-time = "2025-09-11T10:28:59.218Z" },
+]
+
+[[package]]
+name = "opentelemetry-util-http"
+version = "0.58b0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c6/5f/02f31530faf50ef8a41ab34901c05cbbf8e9d76963ba2fb852b0b4065f4e/opentelemetry_util_http-0.58b0.tar.gz", hash = "sha256:de0154896c3472c6599311c83e0ecee856c4da1b17808d39fdc5cce5312e4d89", size = 9411, upload-time = "2025-09-11T11:43:05.602Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/a3/0a1430c42c6d34d8372a16c104e7408028f0c30270d8f3eb6cccf2e82934/opentelemetry_util_http-0.58b0-py3-none-any.whl", hash = "sha256:6c6b86762ed43025fbd593dc5f700ba0aa3e09711aedc36fd48a13b23d8cb1e7", size = 7652, upload-time = "2025-09-11T11:42:09.682Z" },
 ]
 
 [[package]]
@@ -2742,6 +2968,15 @@ wheels = [
 ]
 
 [[package]]
+name = "sqlparse"
+version = "0.5.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/76/437d71068094df0726366574cf3432a4ed754217b436eb7429415cf2d480/sqlparse-0.5.5.tar.gz", hash = "sha256:e20d4a9b0b8585fdf63b10d30066c7c94c5d7a7ec47c889a2d83a3caa93ff28e", size = 120815, upload-time = "2025-12-19T07:17:45.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/4b/359f28a903c13438ef59ebeee215fb25da53066db67b305c125f1c6d2a25/sqlparse-0.5.5-py3-none-any.whl", hash = "sha256:12a08b3bf3eec877c519589833aed092e2444e68240a3577e8e26148acc7b1ba", size = 46138, upload-time = "2025-12-19T07:17:46.573Z" },
+]
+
+[[package]]
 name = "starlette"
 version = "0.47.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2948,14 +3183,23 @@ wheels = [
 
 [[package]]
 name = "typing-inspection"
-version = "0.4.1"
+version = "0.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f8/b1/0c11f5058406b3af7609f121aaa6b609744687f1d158b3c3a5bf4cc94238/typing_inspection-0.4.1.tar.gz", hash = "sha256:6ae134cc0203c33377d43188d4064e9b357dba58cff3185f22924610e70a9d28", size = 75726, upload-time = "2025-05-21T18:55:23.885Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/69/cd203477f944c353c31bade965f880aa1061fd6bf05ded0726ca845b6ff7/typing_inspection-0.4.1-py3-none-any.whl", hash = "sha256:389055682238f53b04f7badcb49b989835495a96700ced5dab2d8feae4b26f51", size = 14552, upload-time = "2025-05-21T18:55:22.152Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Context

Productionises the PoC OpenTelemetry logger util so Consult can pin it as a normal dependency (PRO-659). The foundational OTel code came from Seb's `EN-1501/django-enricher` PoC (credited via co-author); this is the clean release cut, rebased on main with the sandbox demo apps and PoC churn dropped.

## What changed

- OTel logging layer: `configure_otel` plus Django/FastAPI/Lambda bootstrap helpers (tracer + logger providers, composite W3C + X-Ray propagation, OTLP exporters that share endpoint and header handling across traces, logs and metrics, force-flush on exit).
- structlog processors that stamp trace context onto events and emit them as OTLP log records correlated to the active span, with a non-zero timestamp so records don't land at @timestamp=1970 downstream.
- Django middleware: `StructuredLoggingMiddlewareOTel` for request lifecycle logging and `DjangoUserIdMiddleware` for user-id enrichment, with header allowlisting, path exclusions and HTTP semconv fields.
- Packaging: new `otel` and `django` extras (also folded into `all`, which was missing them), version bumped to 0.6.0, the dead `MANIFEST.in` removed, and a `test-logging` make target that needs no backing services.

## Review guidance

- Worth a close look at the OTLP emitter: the PoC emitted via a kwargs `emit()` form that doesn't exist in the OTel API, so records never emitted. It now builds a proper `LogRecord` and emits via `get_logger().emit(record)`, with the test using a real in-memory `LoggerProvider`.
- Release plan once merged: cut as a prod pre-release with a PEP 440 tag (e.g. `0.6.0rc1`). pip won't pull an rc unless it's pinned or `--pre` is passed, so Consult stays safe until it opts in.

CI: lint clean (ruff, mypy, bandit), 290 tests pass at ~89% coverage.
