### PR TITLE
ci(release): add pre-release-to-production PyPI publish channel

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -5,6 +5,19 @@ on:
     types:
       - released
       - prereleased
+  workflow_dispatch:
+    inputs:
+      pypi:
+        description: "Target index. Manual runs are pre-release only."
+        type: choice
+        options:
+          - production
+          - test
+        default: test
+      version:
+        description: "Existing tag to publish (must already exist, e.g. 0.6.0rc1)."
+        type: string
+        required: true
 
 jobs:
   deploy:
@@ -13,29 +26,98 @@ jobs:
     permissions:
         id-token: write
         contents: read
+    outputs:
+      target: ${{ steps.resolve.outputs.target }}
+      tag: ${{ steps.resolve.outputs.tag }}
+      version: ${{ steps.resolve.outputs.version }}
+      maturity: ${{ steps.resolve.outputs.maturity }}
     steps:
+    - name: Resolve release target
+      id: resolve
+      env:
+        EVENT_NAME: ${{ github.event_name }}
+        INPUT_PYPI: ${{ inputs.pypi }}
+        INPUT_VERSION: ${{ inputs.version }}
+        RELEASE_TAG: ${{ github.event.release.tag_name }}
+        RELEASE_PRERELEASE: ${{ github.event.release.prerelease }}
+      run: |
+        set -euo pipefail
+
+        # A PEP 440 pre-release carries an a/b/rc/.dev suffix on the base
+        # X.Y.Z version (case-insensitive). Stable versions do not.
+        is_prerelease() {
+          printf '%s' "$1" | grep -Eiq '^[0-9]+\.[0-9]+\.[0-9]+(rc|a|b|\.dev)'
+        }
+
+        if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+          target="$INPUT_PYPI"
+          tag="$INPUT_VERSION"
+
+          if is_prerelease "$tag"; then
+            maturity="prerelease"
+          else
+            maturity="stable"
+          fi
+
+          # Guardrail: manual dispatch is pre-release only. A stable version
+          # must go through the normal GitHub Release flow, never a manual
+          # publish, to avoid two divergent routes to a production stable
+          # release.
+          if [ "$target" = "production" ] && [ "$maturity" != "prerelease" ]; then
+            echo "::error::Manual dispatch to production is pre-release only. '$tag' is not a PEP 440 pre-release (expected an rc/a/b/.dev suffix). Cut a stable release via the GitHub Release flow instead."
+            exit 1
+          fi
+        else
+          # GitHub Release event: keep today's routing. A GitHub pre-release
+          # goes to Test PyPI; a full release goes to production PyPI.
+          tag="$RELEASE_TAG"
+          if [ "$RELEASE_PRERELEASE" = "true" ]; then
+            target="test"
+            maturity="prerelease"
+          else
+            target="production"
+            maturity="stable"
+          fi
+        fi
+
+        # Version-string stamping (see README CI/CD & Releases):
+        # - test:                  <tag>.<timestamp>  (avoids Test PyPI
+        #                          filename-reuse rejections on re-upload)
+        # - production pre-release: <tag> verbatim     (clean PEP 440 rc so
+        #                          pip ignores it without --pre)
+        # - production stable:      <tag> verbatim
+        if [ "$target" = "test" ]; then
+          timestamp="$(date +"%Y%m%d%H%M")"
+          version="${tag}.${timestamp}"
+        else
+          version="$tag"
+        fi
+
+        {
+          echo "target=$target"
+          echo "tag=$tag"
+          echo "version=$version"
+          echo "maturity=$maturity"
+        } >> "$GITHUB_OUTPUT"
+
+        echo "Resolved: event=$EVENT_NAME target=$target maturity=$maturity tag=$tag version=$version"
+
     - name: Validate semantic version
       uses: matt-usurp/validate-semver@7bbc9584679de1aeef57aa531504ab00438481ab
       with:
-        version: ${{ github.event.release.tag_name }}
+        version: ${{ steps.resolve.outputs.tag }}
 
     - name: Checkout repository
       uses: actions/checkout@v4
       with:
           fetch-depth: 0
+          ref: ${{ steps.resolve.outputs.tag }}
 
     - name: Install uv
       uses: astral-sh/setup-uv@v4
 
-    - name: Set test release version
-      if: github.event.release.prerelease == true
-      run: |
-        timestamp=$(date +"%Y%m%d%H%M")
-        uv version ${{ github.event.release.tag_name }}.$timestamp
-
-    - name: Set prod release version
-      if: github.event.release.prerelease == false
-      run: uv version ${{ github.event.release.tag_name }}
+    - name: Set package version
+      run: uv version ${{ steps.resolve.outputs.version }}
 
     - name: Install dependencies
       run: uv sync
@@ -43,16 +125,16 @@ jobs:
     - name: Build
       run: uv build
 
-    - name: Publish to test pypi
+    - name: Publish to test PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
-      if: github.event.release.prerelease == true
+      if: steps.resolve.outputs.target == 'test'
       with:
         repository-url: 'https://test.pypi.org/legacy/'
         verbose: true
 
-    - name: Publish to prod pypi
+    - name: Publish to production PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
-      if: github.event.release.prerelease == false
+      if: steps.resolve.outputs.target == 'production'
 
   determine-success:
     if: always()
@@ -78,7 +160,7 @@ jobs:
       - determine-success
     with:
       WORKFLOW_PASSED: ${{ needs.determine-success.outputs.success == 'true' }}
-      SUCCESS_PAYLOAD: "{\"blocks\":[{\"type\":\"header\",\"text\":{\"type\":\"plain_text\",\"text\":\":airplane: ${{ github.repository }} - Successfully deployed ${{ github.event.release.tag_name }}${{ github.event.release.prerelease && ' (Pre-Release)' || '' }} :large_green_circle:\"}},{\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\"Package published to${{ github.event.release.prerelease && ' test' || '' }} PyPI successfully\"}}]}"
-      FAILURE_PAYLOAD: "{\"blocks\":[{\"type\":\"header\",\"text\":{\"type\":\"plain_text\",\"text\":\":x: ${{ github.repository }} - Failed to deploy ${{ github.event.release.tag_name }}${{ github.event.release.prerelease && ' (Pre-Release)' || '' }} :x:\"}},{\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\"Failed to publish package to PyPI\"}}]}"
+      SUCCESS_PAYLOAD: "{\"blocks\":[{\"type\":\"header\",\"text\":{\"type\":\"plain_text\",\"text\":\":airplane: ${{ github.repository }} - Successfully deployed ${{ needs.deploy.outputs.tag }}${{ needs.deploy.outputs.maturity == 'prerelease' && (needs.deploy.outputs.target == 'production' && ' (Pre-Release → production PyPI)' || ' (Pre-Release → test PyPI)') || '' }} :large_green_circle:\"}},{\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\"Package published to ${{ needs.deploy.outputs.target == 'test' && 'test' || 'production' }} PyPI successfully\"}}]}"
+      FAILURE_PAYLOAD: "{\"blocks\":[{\"type\":\"header\",\"text\":{\"type\":\"plain_text\",\"text\":\":x: ${{ github.repository }} - Failed to deploy ${{ needs.deploy.outputs.tag || github.event.release.tag_name || inputs.version }}${{ needs.deploy.outputs.maturity == 'prerelease' && (needs.deploy.outputs.target == 'production' && ' (Pre-Release → production PyPI)' || ' (Pre-Release → test PyPI)') || '' }} :x:\"}},{\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\"Failed to publish package to PyPI\"}}]}"
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/README.md
+++ b/README.md
@@ -94,21 +94,46 @@ When making changes or adding tests, please ensure tests run in isolation, as fa
 
 ### CI/CD & Releases
 
-Releases must be manually created, after which the specified package version will be released to PyPI. As such, release names must adhere to semantic versioning. They must *not* be prefixed with a `v`.
+Package versions are published to PyPI by the `Publish python package` workflow. Version names must adhere to semantic versioning and must *not* be prefixed with a `v`. Merging to `main` does **not** publish anything; publishing is always a deliberate action.
 
-You may release a pre-release tag to the test version of PyPI by specifying the release as a pre-release on creation. This allows for the testing of a tag in a safe environment before merging to main.
+There are three publish channels:
 
-To pull a pre-release tag into a consuming repo, point your installer at Test PyPI and pin the exact version (replace the version as required):
+| Channel | How to trigger | Version stamped | Published to |
+|---|---|---|---|
+| **Stable release** | Create a GitHub Release, **not** marked as a pre-release | bare tag (e.g. `0.6.0`) | production PyPI |
+| **Pre-release → production** | Run the workflow manually (`Actions → Publish python package → Run workflow`) with `pypi=production` and an existing pre-release tag | tag verbatim (e.g. `0.6.0rc1`) | production PyPI |
+| **Pre-release → test** | Create a GitHub Release, marked as a pre-release | `<tag>.<timestamp>` | Test PyPI |
+
+Notes:
+
+- **Manual dispatch is pre-release only.** The workflow rejects a manual `production` publish whose version is not a PEP 440 pre-release (an `rc` / `a` / `b` / `.dev` suffix). Cut stable releases through the GitHub Release flow.
+- **The tag must already exist before a manual dispatch.** The workflow checks out the tag you pass; create and push it first.
+
+#### Installing a pre-release
+
+**From production PyPI** (pre-release → production channel): pip will not resolve a PEP 440 pre-release unless you opt in with `--pre` or pin the exact version, so ordinary consumers stay on the latest stable automatically.
 
 ```bash
-uv pip install --index https://test.pypi.org/simple/ --index-strategy unsafe-best-match "i-dot-ai-utilities==0.1.1rc202506301522"
+# opt in to pre-releases (resolves the newest rc)
+pip install --pre "i-dot-ai-utilities[django,otel]"
+
+# or pin the exact pre-release version
+pip install "i-dot-ai-utilities[django,otel]==0.6.0rc1"
+```
+
+**From Test PyPI** (pre-release → test channel): point your installer at Test PyPI, provide production PyPI as a fallback index so runtime dependencies resolve, and pin the exact **timestamped** version the workflow generated (replace the version as required):
+
+```bash
+uv pip install --index https://test.pypi.org/simple/ --index-strategy unsafe-best-match "i-dot-ai-utilities[django,otel]==0.1.1rc202506301522"
 ```
 
 Or with pip:
 
 ```bash
-pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ "i-dot-ai-utilities==0.1.1rc202506301522"
+pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ "i-dot-ai-utilities[django,otel]==0.1.1rc202506301522"
 ```
+
+`--pre` alone is not enough for the Test PyPI channel: the package only exists on Test PyPI, so you must also point the installer at that index (and keep production PyPI as a fallback for dependencies).
 
 ## Licence
 

--- a/src/i_dot_ai_utilities/logging/README.md
+++ b/src/i_dot_ai_utilities/logging/README.md
@@ -188,6 +188,8 @@ Trace correlation on log records comes from a structlog processor reading the ac
 pip install --pre "i-dot-ai-utilities[django,otel]"
 ```
 
+> **Pre-release channels:** this OTel/Django functionality is opt-in and only compatible with our new observability stack — not the existing one. The command above works when the pre-release was published to **production PyPI**. If it was published to **Test PyPI** instead, `--pre` alone is not enough: you must also point the installer at Test PyPI (with a production fallback index for dependencies) and pin the exact timestamped version. See [CI/CD & Releases](../../../README.md#cicd--releases) in the root README for the full per-channel install commands.
+
 **Configure OTel once at startup** (`wsgi.py`, `asgi.py`, or an `AppConfig.ready()`):
 
 ```python


### PR DESCRIPTION
The publish workflow previously offered only two routes, keyed on the GitHub Release pre-release flag: a full release to production PyPI, or a GitHub pre-release to Test PyPI. There was no way to publish a PEP 440 pre-release to production PyPI, so consumers could not opt into an rc via `--pre` from the normal index.

Add a third channel by triggering on workflow_dispatch alongside the release event, with a `pypi` (production|test) choice input and a `version` input for the existing tag to publish. A resolve step computes the target index, tag, final version string, and maturity as job outputs so both trigger types feed one canonical decision.

- Manual dispatch is pre-release only: publishing a non-PEP-440-prerelease version to production fails fast, keeping stable releases on the GitHub Release flow.
- Version stamping: Test PyPI keeps the `<tag>.<timestamp>` scheme to avoid filename-reuse rejections; production publishes the tag verbatim so an rc stays a clean PEP 440 pre-release.
- validate-semver and the checkout ref now source from the resolved tag, so manual dispatch checks out the pre-created tag.
- Publish steps key on the resolved target and are renamed after the destination index rather than release maturity.
- Slack notifications read the deploy job's resolved outputs and gain a third state, with a failure-path fallback for when outputs are empty.

Document all three channels and their per-channel install commands in the root README, and cross-link them from the logging README's install note.